### PR TITLE
WIP custom http headers

### DIFF
--- a/packages/element/src/runtime/Browser.ts
+++ b/packages/element/src/runtime/Browser.ts
@@ -503,6 +503,11 @@ export class Browser<T> implements BrowserInterface {
 		return this.page.setUserAgent(userAgent)
 	}
 
+	@rewriteError()
+	public async setExtraHTTPHeaders(headers: { [key: string]: string }): Promise<void> {
+		return this.page.setExtraHTTPHeaders(headers)
+	}
+
 	/**
 	 * Takes a screenshot of this element and saves it to the results folder with a random name.
 	 */

--- a/packages/element/src/runtime/Settings.ts
+++ b/packages/element/src/runtime/Settings.ts
@@ -116,7 +116,7 @@ export interface TestSettings {
 	clearCookies?: boolean
 
 	/**
-	 * Specifies whether Brwoser cache should be cleared after each test loop.
+	 * Specifies whether Browser cache should be cleared after each test loop.
 	 *
 	 * @default false
 	 */
@@ -126,6 +126,14 @@ export interface TestSettings {
 	 * Disables browser request cache for all requests.
 	 */
 	disableCache?: boolean
+
+	/**
+	 * Specifies a set of extra HTTP headers to set before each test loop.
+	 * If this setting is undefined, the extra HTTP headers are left as-is between iterations.
+	 *
+	 * @default undefined
+	 */
+	extraHTTPHeaders?: { [key: string]: string }
 
 	/**
 	 * Speicifies the name of the test specified in the comments section

--- a/packages/element/src/runtime/Test.ts
+++ b/packages/element/src/runtime/Test.ts
@@ -123,6 +123,8 @@ export default class Test {
 			if (this.settings.device) await browser.emulateDevice(this.settings.device)
 			if (this.settings.userAgent) await browser.setUserAgent(this.settings.userAgent)
 			if (this.settings.disableCache) await browser.setCacheDisabled(true)
+			if (this.settings.extraHTTPHeaders !== undefined)
+				await browser.setExtraHTTPHeaders(this.settings.extraHTTPHeaders)
 
 			debug('running this.before(browser)')
 			await this.testObserver.before(this)

--- a/packages/element/src/runtime/types.ts
+++ b/packages/element/src/runtime/types.ts
@@ -100,6 +100,8 @@ export interface Browser {
 	 */
 	setUserAgent(userAgent: string): Promise<void>
 
+	setExtraHTTPHeaders(headers: { [key: string]: string }): Promise<void>
+
 	/**
 	 * Instructs the browser to navigate to a specific page. This is typically used as the
 	 * entrypoint to your test, as the first instruction it is also responsible for creating


### PR DESCRIPTION
Simple facility for setting custom http headers.
WIP because I'm not quite sure how to test.

Need a repeatable site like `challenge.flood.io` to test this from a smoke test.
I tried setting User-Agent, but you need to do that via `setUserAgent`.
