### PR TITLE
Feat: Additional launch args

### DIFF
--- a/examples/proxy-settings/test.ts
+++ b/examples/proxy-settings/test.ts
@@ -1,0 +1,14 @@
+import { step, TestSettings } from '@flood/element'
+
+export const settings: TestSettings = {
+	loopCount: 1,
+
+	// Pass proxy args to Chrome on launch
+	launchArgs: ['--proxy-server=127.0.0.1:9876'],
+}
+
+export default () => {
+	step('Visit homepage', async b => {
+		await b.visit('https://google.com')
+	})
+}

--- a/examples/proxy-settings/test.ts
+++ b/examples/proxy-settings/test.ts
@@ -3,7 +3,7 @@ import { step, TestSettings } from '@flood/element'
 export const settings: TestSettings = {
 	loopCount: 1,
 
-	// Pass proxy args to Chrome on launch
+	// Pass proxy args to Chrome on launch. For additional flags see https://peter.sh/experiments/chromium-command-line-switches/
 	launchArgs: ['--proxy-server=127.0.0.1:9876'],
 }
 

--- a/packages/element/src/Runner.ts
+++ b/packages/element/src/Runner.ts
@@ -100,11 +100,7 @@ export class Runner {
 		private testSettingOverrides: TestSettings,
 		private launchOptionOverrides: Partial<ConcreteLaunchOptions>,
 		private testObserverFactory: (t: TestObserver) => TestObserver = x => x,
-	) {
-		if (this.launchOptionOverrides.args == null) this.launchOptionOverrides.args = []
-		if (Array.isArray(testSettingOverrides.launchArgs))
-			this.launchOptionOverrides.args.push(...testSettingOverrides.launchArgs)
-	}
+	) {}
 
 	async stop(): Promise<void> {
 		this.running = false
@@ -130,6 +126,9 @@ export class Runner {
 		if (options.chromeVersion === undefined) {
 			options.chromeVersion = settings.chromeVersion
 		}
+
+		if (options.args == null) options.args = []
+		if (Array.isArray(settings.launchArgs)) options.args.push(...settings.launchArgs)
 
 		return this.clientFactory(options)
 	}

--- a/packages/element/src/Runner.ts
+++ b/packages/element/src/Runner.ts
@@ -100,7 +100,11 @@ export class Runner {
 		private testSettingOverrides: TestSettings,
 		private launchOptionOverrides: Partial<ConcreteLaunchOptions>,
 		private testObserverFactory: (t: TestObserver) => TestObserver = x => x,
-	) {}
+	) {
+		if (this.launchOptionOverrides.args == null) this.launchOptionOverrides.args = []
+		if (Array.isArray(testSettingOverrides.launchArgs))
+			this.launchOptionOverrides.args.push(...testSettingOverrides.launchArgs)
+	}
 
 	async stop(): Promise<void> {
 		this.running = false

--- a/packages/element/src/driver/Puppeteer.ts
+++ b/packages/element/src/driver/Puppeteer.ts
@@ -38,8 +38,8 @@ function setupSystemChrome(options: ConcreteLaunchOptions): ConcreteLaunchOption
 		case 'darwin':
 			options.executablePath = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
 			break
-    case 'win32':
-			options.executablePath = 'C:\Program Files (x86)\Google\Chrome\Application\chrome.exe'
+		case 'win32':
+			options.executablePath = 'C:Program Files (x86)GoogleChromeApplicationchrome.exe'
 			break
 		default:
 			// TODO search PATH for chrome

--- a/packages/element/src/runtime/Settings.ts
+++ b/packages/element/src/runtime/Settings.ts
@@ -209,7 +209,7 @@ export interface TestSettings {
 	 */
 	blockedDomains?: string[]
 
-  /*
+	/*
 	 * Automatically apply a wait(Until...) before each action. Defaults to `false`
 	 *
 	 * Accepts either `visible` or `present` as values. Set to `false` to disable (default).
@@ -217,6 +217,12 @@ export interface TestSettings {
 	 * Uses global wait timeout from settings.
 	 */
 	waitUntil?: ElementPresence
+
+	/**
+	 * Additional arguments to pass to the browser instance.
+	 * The list of Chromium flags can be found at https://peter.sh/experiments/chromium-command-line-switches/
+	 */
+	launchArgs?: string[]
 }
 
 /**
@@ -247,6 +253,7 @@ export const DEFAULT_SETTINGS: ConcreteTestSettings = {
 	description: '',
 	disableCache: false,
 	extraHTTPHeaders: {},
+	launchArgs: [],
 }
 
 /**

--- a/packages/element/src/runtime/Test.spec.ts
+++ b/packages/element/src/runtime/Test.spec.ts
@@ -72,6 +72,7 @@ describe('Test', function() {
 			waitUntil: false,
 			disableCache: false,
 			extraHTTPHeaders: {},
+			launchArgs: [],
 		}
 		expect(test.settings).to.deep.equal(defaultSettings)
 	})

--- a/yarn.lock
+++ b/yarn.lock
@@ -7705,10 +7705,6 @@ tsutils@^2.27.2:
   dependencies:
     tslib "^1.8.1"
 
-tti-polyfill@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/tti-polyfill/-/tti-polyfill-0.2.2.tgz#f7bbf71b13afa9edf60c8bb0d0c05f134e1513b9"
-
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"


### PR DESCRIPTION
Adds support for applying additional launch args to Chrome. 

## Usage:

```ts
export const settings: TestSettings = {
  launchArgs: ['--proxy-server=127.0.0.1:9876']
}
```

For a complete list of args, see https://peter.sh/experiments/chromium-command-line-switches/

Closes #78 