### PR TITLE
[bugfix] Loop Count setting does not work

### DIFF
--- a/packages/cli/src/cmd/run.ts
+++ b/packages/cli/src/cmd/run.ts
@@ -86,6 +86,7 @@ const cmd: CommandModule = {
 			testSettingOverrides: {},
 			persistentRunner: false,
 		}
+
 		if (args.loopCount) {
 			opts.testSettingOverrides = {
 				loopCount: args.loopCount,

--- a/packages/cli/src/cmd/run.ts
+++ b/packages/cli/src/cmd/run.ts
@@ -83,12 +83,14 @@ const cmd: CommandModule = {
 			sandbox: args.sandbox ?? true,
 
 			runEnv: initRunEnv(workRootPath, testDataPath),
-			testSettingOverrides: {
-				loopCount: args.loopCount,
-			},
+			testSettingOverrides: {},
 			persistentRunner: false,
 		}
-
+		if (args.loopCount) {
+			opts.testSettingOverrides = {
+				loopCount: args.loopCount,
+			}
+		}
 		opts.testSettingOverrides = setupDelayOverrides(args, opts.testSettingOverrides)
 
 		if (args.watch) {
@@ -167,7 +169,6 @@ const cmd: CommandModule = {
 				describe:
 					'Override the loopCount setting in the test script. This is normally overridden to 1 when running via the cli.',
 				type: 'number',
-				default: 1,
 			})
 			.option('strict', {
 				group: 'Running the test script:',


### PR DESCRIPTION
### What does it do?
when executing the cmd: `element run file.ts`, the `loopCount` always has default value is 1 and it overrides the one which was defined in `TestSetting`. So the fix do the following:
- if the cmd does NOT included the `--loop-count` option, do not set default value is 1 and use the `loopCount` value defined in the TestSetting. If TestSetting does not define `loopCount`, the test will loop infinitely
- if the cmd included `--loop-count` option, it overrides the current one in the TestSetting.

### Ticket 
resolves #91 

### Note
It seems we do not add `.editorconfig` file so when viewing the ts file, the indent is not right.