### PR TITLE
Fix screenshot on failure not working

### DIFF
--- a/examples/screenshot-on-failure/screenshot-on-failure.ts
+++ b/examples/screenshot-on-failure/screenshot-on-failure.ts
@@ -1,0 +1,13 @@
+import { step, By, TestSettings } from '@flood/element'
+
+export const settings: TestSettings = {
+	loopCount: 1,
+	screenshotOnFailure: true,
+}
+
+export default () => {
+	step('1. Start', async browser => {
+		await browser.visit('https://challenge.flood.io')
+		await browser.click(By.css('#foo')) // the selector doesn't exist - will cause error
+	})
+}

--- a/packages/core/src/runtime/test-observers/Errors.ts
+++ b/packages/core/src/runtime/test-observers/Errors.ts
@@ -11,6 +11,10 @@ export default class ErrorObserver extends NoOpTestObserver {
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		test.reporter.testStepError(structuredErrorToDocumentedError(err, test.script)!)
 
+		if (test.settings.screenshotOnFailure) {
+			await test.runningBrowser?.takeScreenshot()
+		}
+
 		return this.next.onStepError(test, step, err)
 	}
 }


### PR DESCRIPTION
Fix `screenshotOnFailure: true` not working 
Screenshot of errors have prefix `error_<stepName>_`
![Screenshot from 2020-04-07 18-08-16](https://user-images.githubusercontent.com/33422297/78662640-fbce9b80-78fa-11ea-81bb-8e268919dbb8.png)
Resolves #87 

Result with example: 
![Screenshot from 2020-04-13 21-41-33](https://user-images.githubusercontent.com/33422297/79129966-5ae75100-7dd0-11ea-8cd6-1d13253ce6c0.png)

