### PR TITLE
feat: text not match waiters

### DIFF
--- a/packages/core/src/page/Until.ts
+++ b/packages/core/src/page/Until.ts
@@ -6,6 +6,7 @@ import {
 } from './conditions/ElementVisibilityCondition'
 import { ElementStateCondition } from './conditions/ElementStateCondition'
 import { ElementSelectedCondition } from './conditions/ElementSelectedCondition'
+import { ElementTextNotMatchCondition } from './conditions/ElementTextNotMatchCondition'
 import { ElementTextCondition } from './conditions/ElementTextCondition'
 import { URLCondition } from './conditions/URLCondition'
 import { DialogCondition } from './conditions/DialogCondition'
@@ -126,6 +127,13 @@ export class Until {
 	}
 
 	/**
+	 * Creates a condition which will wait until the element's text not matches the target text, excluding leading and trailing whitespace.
+	 */
+	static elementTextIsNot(selectorOrLocator: NullableLocatable, text: string): Condition {
+		return new ElementTextNotMatchCondition('elementTextIsNot', selectorOrLocator, text)
+	}
+
+	/**
 	 * Creates a condition which will wait until the element's text content contains the target text.
 	 */
 	static elementTextContains(selectorOrLocator: NullableLocatable, text: string): Condition {
@@ -137,6 +145,17 @@ export class Until {
 	 */
 	static elementTextMatches(selectorOrLocator: NullableLocatable, regex: RegExp): Condition {
 		return new ElementTextCondition('elementTextMatches', selectorOrLocator, regex.toString())
+	}
+
+	/**
+	 * Creates a condition which will wait until the element's text does not match the target Regular Expression.
+	 */
+	static elementTextDoesNotMatch(selectorOrLocator: NullableLocatable, regex: RegExp): Condition {
+		return new ElementTextNotMatchCondition(
+			'elementTextDoesNotMatch',
+			selectorOrLocator,
+			regex.toString(),
+		)
 	}
 
 	/**

--- a/packages/core/src/page/conditions/ElementTextNotMatchCondition.spec.ts
+++ b/packages/core/src/page/conditions/ElementTextNotMatchCondition.spec.ts
@@ -1,0 +1,62 @@
+import { serve } from '../../../tests/support/fixture-server'
+import { launchPuppeteer, testPuppeteer } from '../../../tests/support/launch-browser'
+import { Page } from 'puppeteer'
+import { Until } from '../Until'
+import { By } from '../By'
+
+let page: Page, puppeteer: testPuppeteer
+
+describe('Condition', () => {
+	jest.setTimeout(30e3)
+	beforeAll(async () => {
+		puppeteer = await launchPuppeteer()
+		page = puppeteer.page
+		page.on('console', msg => console.log(`>> console.${msg.type()}: ${msg.text()}`))
+	})
+
+	afterAll(async () => {
+		await puppeteer.close()
+	})
+
+	beforeEach(async () => {
+		const url = await serve('definition_lists.html')
+		await page.goto(url)
+	})
+
+	describe('ElementTextNotMatchCondition', () => {
+		test('waits Until.elementTextIsNot', async () => {
+			const condition = Until.elementTextIsNot(By.css('#name'), 'Name')
+			page.click('#name')
+			const found = await condition.waitFor(page.mainFrame())
+			expect(found).toBe(true)
+		})
+
+		test('waits Until.elementTextDoesNotMatch regex starts with', async () => {
+			const condition = Until.elementTextDoesNotMatch(By.css('#name'), /^Na/)
+			page.click('#name')
+			const found = await condition.waitFor(page.mainFrame())
+			expect(found).toBe(true)
+		})
+
+		test('waits Until.elementTextDoesNotMatch regex ends with', async () => {
+			const condition = Until.elementTextDoesNotMatch(By.css('#name'), /me$/)
+			page.click('#name')
+			const found = await condition.waitFor(page.mainFrame())
+			expect(found).toBe(true)
+		})
+
+		test('waits Until.elementTextDoesNotMatch regex full match', async () => {
+			const condition = Until.elementTextDoesNotMatch(By.css('#name'), /^Name$/)
+			page.click('#name')
+			const found = await condition.waitFor(page.mainFrame())
+			expect(found).toBe(true)
+		})
+
+		test('waits Until.elementTextDoesNotMatch regex contains', async () => {
+			const condition = Until.elementTextDoesNotMatch(By.css('#name'), /am/)
+			page.click('#name')
+			const found = await condition.waitFor(page.mainFrame())
+			expect(found).toBe(true)
+		})
+	})
+})

--- a/packages/core/src/page/conditions/ElementTextNotMatchCondition.ts
+++ b/packages/core/src/page/conditions/ElementTextNotMatchCondition.ts
@@ -1,0 +1,34 @@
+import { ElementCondition, NullableLocatable } from '../Condition'
+import { EvaluateFn } from 'puppeteer'
+
+export class ElementTextNotMatchCondition extends ElementCondition {
+	constructor(desc: string, locator: NullableLocatable, ...args: any[]) {
+		super(desc, locator)
+		this.pageFuncArgs = args
+	}
+
+	toString() {
+		return `waiting for element text to not equal "${this.pageFuncArgs[0]}"`
+	}
+
+	pageFunc: EvaluateFn = (node: HTMLElement, expectedText: string) => {
+		if (!node) return false
+		if (!node.textContent) return false
+		const text = node.textContent.trim()
+
+		if (typeof expectedText === 'string') {
+			if (expectedText.startsWith('/') && expectedText.endsWith('/')) {
+				// RegExp
+				const exp = new RegExp(expectedText.slice(1, expectedText.length - 1))
+				return !exp.test(text)
+			} else {
+				return text !== expectedText
+			}
+		}
+		return false
+	}
+
+	async waitForEvent(): Promise<any> {
+		return
+	}
+}


### PR DESCRIPTION
Added features:

- Until.elementTextIsNot() - Full text not match comparison
- Until.elementTextDoesNotMatch() - Regex not match comparison

Solve a part of feature request in #37 

Remaining feature request in #37 : 
- titleDoesNotMatch(title)
- urlDoesNotMatch(title)
Since they're waiters in different object so I'll have another PR for those 2

Considering
- Until.elementTextDoesNotContain()
=> Use case: Changing only a part of text, like page visit counter increment (but this one can be solved with regex)

Note: please squash merge :D 

