### PR TITLE
Allow user to specify a return code when the test fails

### DIFF
--- a/packages/cli/src/cmd/agent/start.ts
+++ b/packages/cli/src/cmd/agent/start.ts
@@ -1,7 +1,6 @@
 import { CommandModule, Arguments } from 'yargs'
 import { checkFile } from '../common'
 import run from '@flood/element-flood-runner'
-import { runUntilExit } from '@flood/element-api'
 
 interface RunArguments extends Arguments {
 	file: string
@@ -14,7 +13,7 @@ const cmd: CommandModule = {
 	handler(args: RunArguments) {
 		const { file } = args
 
-		return runUntilExit(() => run(file))
+		run(file)
 	},
 
 	builder(yargs) {

--- a/packages/cli/src/cmd/run.ts
+++ b/packages/cli/src/cmd/run.ts
@@ -32,6 +32,7 @@ interface RunArguments extends Arguments {
 	slowMo?: number
 	'work-root'?: string
 	'test-data-root'?: string
+	'fail-status-code'?: number
 }
 
 function setupDelayOverrides(args: RunArguments, testSettingOverrides: TestSettings) {
@@ -85,6 +86,7 @@ const cmd: CommandModule = {
 			runEnv: initRunEnv(workRootPath, testDataPath),
 			testSettingOverrides: {},
 			persistentRunner: false,
+			failStatusCode: args['fail-status-code'],
 		}
 
 		if (args.loopCount) {
@@ -187,6 +189,9 @@ const cmd: CommandModule = {
 			})
 			.option('verbose', {
 				describe: 'Verbose mode',
+			})
+			.option('fail-status-code', {
+				describe: 'Exit code when the test fails',
 			})
 			.positional('file', {
 				describe: 'the test script to run',

--- a/packages/cli/src/cmd/run.ts
+++ b/packages/cli/src/cmd/run.ts
@@ -192,6 +192,7 @@ const cmd: CommandModule = {
 			})
 			.option('fail-status-code', {
 				describe: 'Exit code when the test fails',
+				type: 'number',
 			})
 			.positional('file', {
 				describe: 'the test script to run',

--- a/packages/cli/src/cmd/run.ts
+++ b/packages/cli/src/cmd/run.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import {
 	runCommandLine,
-	runUntilExit,
 	ElementOptions,
 	WorkRoot,
 	FloodProcessEnv,
@@ -32,7 +31,7 @@ interface RunArguments extends Arguments {
 	slowMo?: number
 	'work-root'?: string
 	'test-data-root'?: string
-	'fail-status-code'?: number
+	'fail-status-code': number
 }
 
 function setupDelayOverrides(args: RunArguments, testSettingOverrides: TestSettings) {
@@ -101,7 +100,7 @@ const cmd: CommandModule = {
 			opts.testCommander = makeTestCommander(file)
 		}
 
-		runUntilExit(() => runCommandLine(opts))
+		runCommandLine(opts)
 	},
 	builder(yargs: Argv): Argv {
 		return yargs
@@ -193,6 +192,7 @@ const cmd: CommandModule = {
 			.option('fail-status-code', {
 				describe: 'Exit code when the test fails',
 				type: 'number',
+				default: 1,
 			})
 			.positional('file', {
 				describe: 'the test script to run',

--- a/packages/core/api.ts
+++ b/packages/core/api.ts
@@ -10,7 +10,7 @@ export {
 
 // XYZ
 
-export { runCommandLine, runUntilExit, ElementOptions } from './src/Element'
+export { runCommandLine, ElementOptions } from './src/Element'
 
 export { RuntimeEnvironment } from './src/runtime-environment/types'
 export { nullRuntimeEnvironment } from './src/runtime-environment/NullRuntimeEnvironment'

--- a/packages/core/src/Element.ts
+++ b/packages/core/src/Element.ts
@@ -27,12 +27,13 @@ export interface ElementOptions {
 	testObserverFactory?: (t: TestObserver) => TestObserver
 	persistentRunner: boolean
 	testCommander?: TestCommander
+	failStatusCode?: number
 }
 
-export function runUntilExit(fn: () => Promise<void>) {
+export function runUntilExit(fn: () => Promise<number>) {
 	fn()
-		.then(() => {
-			process.exit(0)
+		.then((code: number) => {
+			process.exit(code)
 		})
 		.catch(err => {
 			console.log('Element exited with error')
@@ -41,7 +42,7 @@ export function runUntilExit(fn: () => Promise<void>) {
 		})
 }
 
-export async function runCommandLine(opts: ElementOptions): Promise<void> {
+export async function runCommandLine(opts: ElementOptions): Promise<number> {
 	const { logger, testScript, clientFactory } = opts
 
 	// TODO proper types for args
@@ -95,5 +96,8 @@ export async function runCommandLine(opts: ElementOptions): Promise<void> {
 		return new EvaluatedScript(opts.runEnv, await mustCompileFile(testScript, testScriptOptions))
 	}
 
-	await runner.run(testScriptFactory)
+	const result = await runner.run(testScriptFactory)
+	const exitCode = opts.failStatusCode ? opts.failStatusCode : 0
+
+	return result ? 0 : exitCode
 }

--- a/packages/core/src/runtime/ITest.ts
+++ b/packages/core/src/runtime/ITest.ts
@@ -19,7 +19,7 @@ export interface ITest {
 	cancel(): Promise<void>
 	beforeRun(): Promise<void>
 	run(iteration?: number): Promise<void>
-	runWithCancellation(iteration: number, cancelToken: CancellationToken): Promise<void>
+	runWithCancellation(iteration: number, cancelToken: CancellationToken): Promise<boolean>
 	runStep(
 		testObserver: TestObserver,
 		browser: Browser<Step>,

--- a/packages/core/src/runtime/ITest.ts
+++ b/packages/core/src/runtime/ITest.ts
@@ -19,7 +19,7 @@ export interface ITest {
 	cancel(): Promise<void>
 	beforeRun(): Promise<void>
 	run(iteration?: number): Promise<void>
-	runWithCancellation(iteration: number, cancelToken: CancellationToken): Promise<boolean>
+	runWithCancellation(iteration: number, cancelToken: CancellationToken): Promise<void>
 	runStep(
 		testObserver: TestObserver,
 		browser: Browser<Step>,

--- a/packages/core/src/runtime/Test.ts
+++ b/packages/core/src/runtime/Test.ts
@@ -92,7 +92,7 @@ export default class Test implements ITest {
 	public async runWithCancellation(
 		iteration: number,
 		cancelToken: CancellationToken,
-	): Promise<void> {
+	): Promise<boolean> {
 		console.assert(this.client, `client is not configured in Test`)
 
 		const testObserver = new ErrorObserver(
@@ -154,7 +154,7 @@ export default class Test implements ITest {
 					cancelToken.promise,
 				])
 
-				if (cancelToken.isCancellationRequested) return
+				if (cancelToken.isCancellationRequested) return true
 
 				if (this.failed) {
 					console.log('failed, bailing out of steps')
@@ -171,6 +171,8 @@ export default class Test implements ITest {
 
 		// TODO report skipped steps
 		await testObserver.after(this)
+
+		return !this.failed
 	}
 
 	get currentURL(): string {

--- a/packages/core/src/runtime/Test.ts
+++ b/packages/core/src/runtime/Test.ts
@@ -92,7 +92,7 @@ export default class Test implements ITest {
 	public async runWithCancellation(
 		iteration: number,
 		cancelToken: CancellationToken,
-	): Promise<boolean> {
+	): Promise<void> {
 		console.assert(this.client, `client is not configured in Test`)
 
 		const testObserver = new ErrorObserver(
@@ -154,11 +154,11 @@ export default class Test implements ITest {
 					cancelToken.promise,
 				])
 
-				if (cancelToken.isCancellationRequested) return true
+				if (cancelToken.isCancellationRequested) return
 
 				if (this.failed) {
 					console.log('failed, bailing out of steps')
-					break
+					throw Error('test failed')
 				}
 			}
 		} catch (err) {
@@ -171,8 +171,6 @@ export default class Test implements ITest {
 
 		// TODO report skipped steps
 		await testObserver.after(this)
-
-		return !this.failed
 	}
 
 	get currentURL(): string {

--- a/packages/element-api/index.ts
+++ b/packages/element-api/index.ts
@@ -10,7 +10,7 @@ export {
 
 // XYZ
 
-export { runCommandLine, runUntilExit, ElementOptions } from '@flood/element-core'
+export { runCommandLine, ElementOptions } from '@flood/element-core'
 
 export { TestSettings, ResponseTiming } from '@flood/element-core'
 export { RuntimeEnvironment, FloodProcessEnv } from '@flood/element-core'

--- a/packages/flood-runner/src/Grid.ts
+++ b/packages/flood-runner/src/Grid.ts
@@ -6,7 +6,7 @@ import { initConfig } from './initConfig'
 import { startConcurrencyTicker } from './tickerInterval'
 import { initInfluxReporter } from './initInfluxReporter'
 
-export async function run(file: string): Promise<void> {
+export async function run(file: string): Promise<number> {
 	const gridConfig = initConfig()
 	const influxReporter = initInfluxReporter(gridConfig)
 

--- a/packages/flood-runner/src/Grid.ts
+++ b/packages/flood-runner/src/Grid.ts
@@ -6,7 +6,7 @@ import { initConfig } from './initConfig'
 import { startConcurrencyTicker } from './tickerInterval'
 import { initInfluxReporter } from './initInfluxReporter'
 
-export async function run(file: string): Promise<number> {
+export async function run(file: string): Promise<void> {
 	const gridConfig = initConfig()
 	const influxReporter = initInfluxReporter(gridConfig)
 
@@ -32,6 +32,7 @@ export async function run(file: string): Promise<number> {
 		testSettingOverrides: {},
 		testObserverFactory,
 		persistentRunner: false,
+		failStatusCode: 1,
 	}
 
 	if (gridConfig.testDuration !== undefined) {


### PR DESCRIPTION
User can pass in the option **fail-status-code** to the command `element run test.ts` to be the exit code when the test fails, otherwise exit code is 0.

resolve #30 