### PR TITLE
Feature/add not match waiters

### DIFF
--- a/packages/core/src/page/Until.ts
+++ b/packages/core/src/page/Until.ts
@@ -1,4 +1,5 @@
 import { TitleCondition } from './conditions/TitleCondition'
+import { TitleNotMatchCondition } from './conditions/TitleNotMatchCondition'
 import {
 	ElementVisibilityCondition,
 	ElementLocatedCondition,
@@ -187,6 +188,13 @@ export class Until {
 	}
 
 	/**
+	 * Creates a condition which waits until the page title does not contain the expected text.
+	 */
+	static titleDoesNotContain(title: string): Condition {
+		return new TitleNotMatchCondition('titleContains', title, true)
+	}
+
+	/**
 	 * Creates a condition which waits until the page title exactly matches the expected text.
 	 */
 	static titleIs(title: string): Condition {
@@ -194,10 +202,24 @@ export class Until {
 	}
 
 	/**
+	 * Creates a condition which waits until the page title does not match the expected text.
+	 */
+	static titleIsNot(title: string): Condition {
+		return new TitleNotMatchCondition('titleIs', title, false)
+	}
+
+	/**
 	 * Creates a condition which waits until the page title matches the title `RegExp`.
 	 */
 	static titleMatches(title: RegExp): Condition {
 		return new TitleCondition('titleMatches', `${title}`, false)
+	}
+
+	/**
+	 * Creates a condition which waits until the page title doesn not match the title `RegExp`.
+	 */
+	static titleDoesNotMatch(title: RegExp): Condition {
+		return new TitleNotMatchCondition('titleMatches', `${title}`, false)
 	}
 
 	/**

--- a/packages/core/src/page/Until.ts
+++ b/packages/core/src/page/Until.ts
@@ -14,6 +14,7 @@ import { DialogCondition } from './conditions/DialogCondition'
 import { FrameCondition } from './conditions/FrameCondition'
 import { Condition } from './Condition'
 import { NullableLocatable, Locatable } from '../runtime/types'
+import { URLNotMatchCondition } from './conditions/URLNotMatchCondition'
 
 /**
  * Until contains a wealth of useful <Condition>s.
@@ -230,6 +231,13 @@ export class Until {
 	}
 
 	/**
+	 * Creates a condition which waits until the page URL does not contain the expected path.
+	 */
+	static urlDoesNotContain(url: string): Condition {
+		return new URLNotMatchCondition('urlContains', url, true)
+	}
+
+	/**
 	 * Creates a condition which waits until the page URL exactly matches the expected URL.
 	 */
 	static urlIs(url: string): Condition {
@@ -237,9 +245,23 @@ export class Until {
 	}
 
 	/**
+	 * Creates a condition which waits until the page URL does not match the expected URL.
+	 */
+	static urlIsNot(url: string): Condition {
+		return new URLNotMatchCondition('urlIsNot', url, false)
+	}
+
+	/**
 	 * Creates a condition which waits until the page URL matches the supplied `RegExp`.
 	 */
 	static urlMatches(url: RegExp): Condition {
 		return new URLCondition('urlMatches', url.toString(), true)
+	}
+
+	/**
+	 * Creates a condition which waits until the page URL does not match the supplied `RegExp`.
+	 */
+	static urlDoesNotMatch(url: string): Condition {
+		return new URLNotMatchCondition('urlDoesNotMatch', url.toString(), false)
 	}
 }

--- a/packages/core/src/page/Until.ts
+++ b/packages/core/src/page/Until.ts
@@ -139,6 +139,12 @@ export class Until {
 	static elementTextContains(selectorOrLocator: NullableLocatable, text: string): Condition {
 		return new ElementTextCondition('elementTextContains', selectorOrLocator, text, true)
 	}
+	/**
+	 * Creates a condition which will wait until the element's text content does not contain the target text.
+	 */
+	static elementTextDoesNotContain(selectorOrLocator: NullableLocatable, text: string): Condition {
+		return new ElementTextNotMatchCondition('elementTextContains', selectorOrLocator, text, true)
+	}
 
 	/**
 	 * Creates a condition which will wait until the element's text matches the target Regular Expression.

--- a/packages/core/src/page/conditions/ElementTextNotMatchCondition.spec.ts
+++ b/packages/core/src/page/conditions/ElementTextNotMatchCondition.spec.ts
@@ -30,6 +30,12 @@ describe('Condition', () => {
 			const found = await condition.waitFor(page.mainFrame())
 			expect(found).toBe(true)
 		})
+		test('waits Until.elementTextDoesNotContain', async () => {
+			const condition = Until.elementTextDoesNotContain(By.css('#name'), 'ame')
+			page.click('#name')
+			const found = await condition.waitFor(page.mainFrame())
+			expect(found).toBe(true)
+		})
 
 		test('waits Until.elementTextDoesNotMatch regex starts with', async () => {
 			const condition = Until.elementTextDoesNotMatch(By.css('#name'), /^Na/)

--- a/packages/core/src/page/conditions/ElementTextNotMatchCondition.ts
+++ b/packages/core/src/page/conditions/ElementTextNotMatchCondition.ts
@@ -11,7 +11,7 @@ export class ElementTextNotMatchCondition extends ElementCondition {
 		return `waiting for element text to not equal "${this.pageFuncArgs[0]}"`
 	}
 
-	pageFunc: EvaluateFn = (node: HTMLElement, expectedText: string) => {
+	pageFunc: EvaluateFn = (node: HTMLElement, expectedText: string, partial: boolean = false) => {
 		if (!node) return false
 		if (!node.textContent) return false
 		const text = node.textContent.trim()
@@ -21,6 +21,8 @@ export class ElementTextNotMatchCondition extends ElementCondition {
 				// RegExp
 				const exp = new RegExp(expectedText.slice(1, expectedText.length - 1))
 				return !exp.test(text)
+			} else if (partial) {
+				return text.indexOf(expectedText) === -1
 			} else {
 				return text !== expectedText
 			}

--- a/packages/core/src/page/conditions/TitleNotMatchCondition.spec.ts
+++ b/packages/core/src/page/conditions/TitleNotMatchCondition.spec.ts
@@ -1,0 +1,105 @@
+import { serve } from '../../../tests/support/fixture-server'
+import { launchPuppeteer, testPuppeteer } from '../../../tests/support/launch-browser'
+import { Page } from 'puppeteer'
+import { Until } from '../Until'
+
+let page: Page, puppeteer: testPuppeteer
+
+describe('Condition', () => {
+	jest.setTimeout(30e3)
+	describe('TitleCondition', () => {
+		beforeAll(async () => {
+			puppeteer = await launchPuppeteer()
+			page = puppeteer.page
+		})
+
+		afterAll(async () => {
+			await puppeteer.close()
+		})
+
+		beforeEach(async () => {
+			let url = await serve('wait.html')
+			await page.goto(url)
+		})
+
+		test('waits Until.titleIsNot', async () => {
+			let condition = Until.titleIsNot('wait test')
+
+			await page.evaluate(() => {
+				return new Promise(yeah => {
+					setTimeout(() => {
+						document.title = 'another title'
+						yeah()
+					}, 100)
+				})
+			})
+
+			let result = await condition.waitFor(page.mainFrame())
+			expect(result).toBe(true)
+		})
+
+		test('waits Until.titleDoesNotContain', async () => {
+			let condition = Until.titleDoesNotContain('wait test')
+
+			await page.evaluate(() => {
+				return new Promise(yeah => {
+					setTimeout(() => {
+						document.title = 'another title again'
+						yeah()
+					}, 100)
+				})
+			})
+
+			let result = await condition.waitFor(page.mainFrame())
+			expect(result).toBe(true)
+		})
+
+		test('waits Until.titleMatches regex starts with', async () => {
+			let condition = Until.titleDoesNotMatch(/^wait/)
+
+			await page.evaluate(() => {
+				return new Promise(yeah => {
+					setTimeout(() => {
+						document.title = 'another title again'
+						yeah()
+					}, 100)
+				})
+			})
+
+			let result = await condition.waitFor(page.mainFrame())
+			expect(result).toBe(true)
+		})
+
+		test('waits Until.titleMatches regex ends with', async () => {
+			let condition = Until.titleDoesNotMatch(/test$/)
+
+			await page.evaluate(() => {
+				return new Promise(yeah => {
+					setTimeout(() => {
+						document.title = 'another title again'
+						yeah()
+					}, 100)
+				})
+			})
+
+			let result = await condition.waitFor(page.mainFrame())
+			expect(result).toBe(true)
+		})
+
+		test('waits Until.titleMatches regex full match', async () => {
+			let condition = Until.titleDoesNotMatch(/^wait test$/)
+
+			await page.evaluate(() => {
+				return new Promise(yeah => {
+					setTimeout(() => {
+						document.title = 'another title again'
+						yeah()
+					}, 100)
+				})
+			})
+
+			let result = await condition.waitFor(page.mainFrame())
+			expect(result).toBe(true)
+		})
+	})
+})

--- a/packages/core/src/page/conditions/TitleNotMatchCondition.ts
+++ b/packages/core/src/page/conditions/TitleNotMatchCondition.ts
@@ -1,0 +1,38 @@
+import { Condition } from '../Condition'
+import { Frame } from 'puppeteer'
+
+export class TitleNotMatchCondition extends Condition {
+	constructor(desc: string, public expectedTitle: string, public partial: boolean = false) {
+		super(desc)
+	}
+
+	toString() {
+		return `page title to equal '${this.expectedTitle}'`
+	}
+
+	public async waitFor(frame: Frame): Promise<boolean> {
+		await frame.waitForFunction(
+			(title: string, partial: boolean) => {
+				if (typeof title === 'string') {
+					if (title.startsWith('/') && title.endsWith('/')) {
+						// RegExp
+						const exp = new RegExp(title.slice(1, title.length - 1))
+						return !exp.test(document.title)
+					} else if (partial) {
+						return document.title.indexOf(title) === -1
+					} else {
+						return document.title.trim() !== title.trim()
+					}
+				}
+			},
+			{ polling: 'mutation', timeout: 30e3 },
+			this.expectedTitle,
+			this.partial === true,
+		)
+		return true
+	}
+
+	public async waitForEvent(): Promise<any> {
+		return
+	}
+}

--- a/packages/core/src/page/conditions/URLNotMatchCondition.spec.ts
+++ b/packages/core/src/page/conditions/URLNotMatchCondition.spec.ts
@@ -1,0 +1,54 @@
+import { serve } from '../../../tests/support/fixture-server'
+import { launchPuppeteer, testPuppeteer } from '../../../tests/support/launch-browser'
+import { Page } from 'puppeteer'
+import { Until } from '../Until'
+import { URL } from 'url'
+let page: Page, puppeteer: testPuppeteer
+
+describe('Condition', () => {
+	jest.setTimeout(10e3)
+	describe('URLCondition', () => {
+		beforeAll(async () => {
+			puppeteer = await launchPuppeteer()
+			page = puppeteer.page
+		})
+
+		afterAll(async () => {
+			await puppeteer.close()
+		})
+
+		let url: any
+
+		beforeEach(async () => {
+			url = await serve('timeout_window_location.html')
+			await page.goto(url)
+		})
+
+		test('waits Until.urlIsNot', async () => {
+			const uri = new URL(url)
+			uri.pathname = 'timeout_window_location.html'
+
+			const condition = Until.urlIs(uri.toString())
+			const result = await condition.waitFor(page.mainFrame())
+			expect(result).toBe(true)
+		})
+
+		test('waits Until.urlDoesNotMatch', async () => {
+			const condition = Until.urlMatches(/meout_window_locati/)
+			const result = await condition.waitFor(page.mainFrame())
+			expect(result).toBe(true)
+		})
+
+		test('waits Until.urlDoesNotMatch regex ends with', async () => {
+			const condition = Until.urlMatches(/_window_location.html$/)
+			const result = await condition.waitFor(page.mainFrame())
+			expect(result).toBe(true)
+		})
+
+		test('waits Until.urlDoesNotContain', async () => {
+			const condition = Until.urlContains('eout_window_locati')
+			const result = await condition.waitFor(page.mainFrame())
+			expect(result).toBe(true)
+		})
+	})
+})

--- a/packages/core/src/page/conditions/URLNotMatchCondition.ts
+++ b/packages/core/src/page/conditions/URLNotMatchCondition.ts
@@ -1,0 +1,43 @@
+import { Condition } from '../Condition'
+import { Frame } from 'puppeteer'
+import { pairs } from 'd3-array'
+
+export class URLNotMatchCondition extends Condition {
+	constructor(desc: string, public url: string, public partial: boolean = false) {
+		super(desc)
+	}
+
+	toString() {
+		return `waiting for URL to equal "${this.url}"`
+	}
+
+	public async waitFor(frame: Frame): Promise<boolean> {
+		await frame.waitForFunction(
+			(url: string, partial: boolean) => {
+				if (typeof url === 'string') {
+					if (url.startsWith('/') && url.endsWith('/')) {
+						// RegExp
+						const exp = new RegExp(url.slice(1, url.length - 1))
+						return !exp.test(window.location.href)
+					}
+
+					const currentUrl = window.location.href.trim().toLowerCase()
+					const expectedUrl = url.trim().toLowerCase()
+					if (partial) {
+						return currentUrl.indexOf(expectedUrl) === -1
+					} else {
+						return currentUrl !== expectedUrl
+					}
+				}
+			},
+			{ polling: 'raf', timeout: 30e3 },
+			this.url,
+			this.partial === true,
+		)
+		return true
+	}
+
+	public async waitForEvent(): Promise<any> {
+		return
+	}
+}


### PR DESCRIPTION
Added features:
Until.urlDoesNotContain() - partial url text not match comparison
Until.urlIsNot() - full url text not match comparison
Until.urlDoesNotMatch() - regex url not match comparison
Until.titleDoesNotContain() - partial text title not match comparison
Until.titleIsNot() - full title text not match comparison
Until.titleDoesNotMatch() - regex title not match comparison
Until.elementTextDoesNotContain()

Resolves #37 