### PR TITLE
feature/add step recovery

### DIFF
--- a/examples/condition/test.ts
+++ b/examples/condition/test.ts
@@ -23,7 +23,7 @@ export default () => {
 		},
 	)
 	step.skip('Test skip', async browser => {
-		console.log('Test skip')
+		console.log('This step will not be run')
 	})
 	step('Step pending')
 

--- a/examples/condition/test.ts
+++ b/examples/condition/test.ts
@@ -1,18 +1,13 @@
-import { step, TestSettings } from '@flood/element'
+import { step, TestSettings, RecoveryOption } from '@flood/element'
 
 export const settings: TestSettings = {
-	loopCount: 2,
+	loopCount: 1,
 }
 
 export default () => {
-	step('Test normal', async browser => {
-		console.log('Step normal is still runs')
-	})
-
 	step.once('Test once', async browser => {
 		console.log('Step once runs 1 time')
 	})
-
 	step.if(
 		() => true,
 		'Test if',
@@ -20,7 +15,6 @@ export default () => {
 			console.log('Step if runs with condition true')
 		},
 	)
-
 	step.unless(
 		() => false,
 		'Test unless',
@@ -28,10 +22,55 @@ export default () => {
 			console.log('Test unless runs with condition false')
 		},
 	)
-
 	step.skip('Test skip', async browser => {
 		console.log('Test skip')
 	})
-
 	step('Step pending')
+
+	let retry = false
+	let restart = false
+
+	step.recovery('Step 1', async browser => {
+		console.log('Recovery step 1 done, retry step 1')
+		return RecoveryOption.RETRY
+	})
+
+	step.recovery('Step 2', async browser => {
+		console.log('Recovery step 2 done, restart step 1')
+		return RecoveryOption.RESTART
+	})
+
+	step.recovery('Step 3', async browser => {
+		console.log('Recovery step 3 done, throw an error')
+		return RecoveryOption.ERROR
+	})
+
+	step('Step 1', async browser => {
+		if (!retry) {
+			retry = true
+			console.log('Fail step 1, call recovery')
+			throw Error('Fail')
+		} else {
+			console.log('Done step 1')
+		}
+	})
+
+	step('Step 2', async browser => {
+		if (!restart) {
+			restart = true
+			console.log('Fail step 2, call recovery')
+			throw Error('Fail')
+		} else {
+			console.log('Done step 2')
+		}
+	})
+
+	step('Step 3', async browser => {
+		console.log('Throw error step 3')
+		throw Error('Fail')
+	})
+
+	step('Step 4', async browser => {
+		console.log('Done step 4')
+	})
 }

--- a/examples/condition/test.ts
+++ b/examples/condition/test.ts
@@ -1,4 +1,4 @@
-import { step, TestSettings, RecoveryOption } from '@flood/element'
+import { step, TestSettings, RecoverWith } from '@flood/element'
 
 export const settings: TestSettings = {
 	loopCount: 1,
@@ -32,17 +32,17 @@ export default () => {
 
 	step.recovery('Step 1', async browser => {
 		console.log('Recovery step 1 done, retry step 1')
-		return RecoveryOption.RETRY
+		return RecoverWith.RETRY
 	})
 
 	step.recovery('Step 2', async browser => {
 		console.log('Recovery step 2 done, restart step 1')
-		return RecoveryOption.RESTART
+		return RecoverWith.RESTART
 	})
 
 	step.recovery('Step 3', async browser => {
 		console.log('Recovery step 3 done, throw an error')
-		return RecoveryOption.ERROR
+		return RecoverWith.CONTINUE
 	})
 
 	step('Step 1', async browser => {

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -108,7 +108,7 @@ export {
 /**
  * @docPage DSL
  */
-export { step, TestFn, StepFunction, StepOptions } from './src/runtime/Step'
+export { step, TestFn, StepFunction, StepOptions, RecoveryOption } from './src/runtime/Step'
 
 /**
  * @docPage DSL

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -108,7 +108,7 @@ export {
 /**
  * @docPage DSL
  */
-export { step, TestFn, StepFunction, StepOptions, RecoveryOption } from './src/runtime/Step'
+export { step, TestFn, StepFunction, StepOptions, RecoverWith } from './src/runtime/Step'
 
 /**
  * @docPage DSL

--- a/packages/core/src/Looper.ts
+++ b/packages/core/src/Looper.ts
@@ -1,0 +1,68 @@
+import { ConcreteTestSettings } from './runtime/Settings'
+
+export class Looper {
+	public iterations = 0
+	private timeout: any
+	private cancelled = false
+	private loopCount: number
+
+	public done: Promise<void>
+	private doneResolve: () => void
+
+	constructor(settings: ConcreteTestSettings, running = true) {
+		if (settings.duration > 0) {
+			this.timeout = setTimeout(() => {
+				this.cancelled = true
+			}, settings.duration * 1e3)
+		}
+
+		this.loopCount = settings.loopCount
+		this.cancelled = !running
+		this.done = new Promise(resolve => (this.doneResolve = resolve))
+	}
+
+	stop() {
+		this.cancelled = true
+	}
+
+	async kill(): Promise<void> {
+		if (this._killer !== undefined) {
+			this._killer()
+		}
+		this.cancelled = true
+
+		await this.done
+	}
+
+	_killer: () => void
+	set killer(killCb: () => void) {
+		this._killer = killCb
+	}
+
+	finish() {
+		clearTimeout(this.timeout)
+	}
+
+	get continueLoop(): boolean {
+		const hasInfiniteLoops = this.loopCount <= 0
+		const hasLoopsLeft = this.iterations < this.loopCount
+
+		return !this.cancelled && (hasLoopsLeft || hasInfiniteLoops)
+	}
+
+	restartLoop() {
+		this.iterations -= 1
+	}
+
+	async run(iterator: (iteration: number) => Promise<void>): Promise<number> {
+		while (this.continueLoop) {
+			await iterator(++this.iterations)
+		}
+		this.finish()
+
+		// XXX perhaps call this in a finally to ensure it gets called
+		this.doneResolve()
+
+		return this.iterations
+	}
+}

--- a/packages/core/src/Runner.ts
+++ b/packages/core/src/Runner.ts
@@ -3,11 +3,12 @@ import { Logger } from 'winston'
 import Test from './runtime/Test'
 import { EvaluatedScript } from './runtime/EvaluatedScript'
 import { TestObserver } from './runtime/test-observers/Observer'
-import { TestSettings, ConcreteTestSettings } from './runtime/Settings'
+import { TestSettings } from './runtime/Settings'
 import { IReporter } from './Reporter'
 import { AsyncFactory } from './utils/Factory'
 import { CancellationToken } from './utils/CancellationToken'
 import { TestScriptError } from './TestScriptError'
+import { Looper } from './Looper'
 
 export interface TestCommander {
 	on(event: 'rerun-test', listener: () => void): this
@@ -22,73 +23,6 @@ function delay(t: number, v?: any) {
 	return new Promise(function(resolve) {
 		setTimeout(resolve.bind(null, v), t)
 	})
-}
-
-export class Looper {
-	public iterations = 0
-	private timeout: any
-	private cancelled = false
-	private loopCount: number
-
-	public done: Promise<void>
-	private doneResolve: () => void
-
-	constructor(settings: ConcreteTestSettings, running = true) {
-		if (settings.duration > 0) {
-			this.timeout = setTimeout(() => {
-				this.cancelled = true
-			}, settings.duration * 1e3)
-		}
-
-		this.loopCount = settings.loopCount
-		this.cancelled = !running
-		this.done = new Promise(resolve => (this.doneResolve = resolve))
-	}
-
-	stop() {
-		this.cancelled = true
-	}
-
-	async kill(): Promise<void> {
-		if (this._killer !== undefined) {
-			this._killer()
-		}
-		this.cancelled = true
-
-		await this.done
-	}
-
-	_killer: () => void
-	set killer(killCb: () => void) {
-		this._killer = killCb
-	}
-
-	finish() {
-		clearTimeout(this.timeout)
-	}
-
-	get continueLoop(): boolean {
-		const hasInfiniteLoops = this.loopCount <= 0
-		const hasLoopsLeft = this.iterations < this.loopCount
-
-		return !this.cancelled && (hasLoopsLeft || hasInfiniteLoops)
-	}
-
-	restartLoop() {
-		this.iterations -= 1
-	}
-
-	async run(iterator: (iteration: number) => Promise<void>): Promise<number> {
-		while (this.continueLoop) {
-			await iterator(++this.iterations)
-		}
-		this.finish()
-
-		// XXX perhaps call this in a finally to ensure it gets called
-		this.doneResolve()
-
-		return this.iterations
-	}
 }
 
 export class Runner {

--- a/packages/core/src/Runner.ts
+++ b/packages/core/src/Runner.ts
@@ -24,7 +24,7 @@ function delay(t: number, v?: any) {
 	})
 }
 
-class Looper {
+export class Looper {
 	public iterations = 0
 	private timeout: any
 	private cancelled = false
@@ -72,6 +72,10 @@ class Looper {
 		const hasLoopsLeft = this.iterations < this.loopCount
 
 		return !this.cancelled && (hasLoopsLeft || hasInfiniteLoops)
+	}
+
+	restartLoop() {
+		this.iterations -= 1
 	}
 
 	async run(iterator: (iteration: number) => Promise<void>): Promise<number> {
@@ -181,7 +185,7 @@ export class Runner {
 
 				const startTime = new Date()
 				try {
-					await test.runWithCancellation(iteration, cancelToken)
+					await test.runWithCancellation(iteration, cancelToken, this.looper)
 				} catch (err) {
 					this.logger.error(
 						`[Iteration: ${iteration}] Error in Runner Loop: ${err.name}: ${err.message}\n${err.stack}`,

--- a/packages/core/src/runtime/EvaluatedScript.ts
+++ b/packages/core/src/runtime/EvaluatedScript.ts
@@ -239,7 +239,7 @@ export class EvaluatedScript implements TestScriptErrorMapper, EvaluatedScriptLi
 			const [options, fn] = extractOptionsAndCallback(optionsOrFn)
 			recoverySteps[name] = {
 				recoveryStep: { name, options, fn },
-				loopCount: options.maxRecovery || -1,
+				loopCount: options.maxRecovery || 0,
 			}
 		}
 

--- a/packages/core/src/runtime/EvaluatedScript.ts
+++ b/packages/core/src/runtime/EvaluatedScript.ts
@@ -17,7 +17,7 @@ import {
 	ConditionFn,
 	StepExtended,
 	StepRecoveryObject,
-	RecoveryOption,
+	RecoverWith,
 } from './Step'
 import { SuiteDefinition, Browser } from './types'
 import Test from './Test'
@@ -237,7 +237,10 @@ export class EvaluatedScript implements TestScriptErrorMapper, EvaluatedScriptLi
 
 		step.recovery = async (name: string, ...optionsOrFn: any[]) => {
 			const [options, fn] = extractOptionsAndCallback(optionsOrFn)
-			recoverySteps[name] = { name, options, fn }
+			recoverySteps[name] = {
+				recoveryStep: { name, options, fn },
+				loopCount: options.maxRecovery || -1,
+			}
 		}
 
 		const context = {
@@ -257,7 +260,7 @@ export class EvaluatedScript implements TestScriptErrorMapper, EvaluatedScriptLi
 			MouseButtons,
 			TestData: this.testDataLoaders,
 			Key,
-			RecoveryOption,
+			RecoverWith,
 			userAgents,
 			suite: captureSuite,
 		}

--- a/packages/core/src/runtime/EvaluatedScriptLike.ts
+++ b/packages/core/src/runtime/EvaluatedScriptLike.ts
@@ -3,9 +3,11 @@ import { TestSettings } from './Settings'
 import { TestDataSource } from '../test-data/TestData'
 import { ITest } from './ITest'
 import { RuntimeEnvironment } from '../runtime-environment/types'
+import { Step, StepRecoveryObject } from './Step'
 
 export interface EvaluatedScriptLike {
-	steps: any[]
+	steps: Step[]
+	recoverySteps: StepRecoveryObject
 	settings: TestSettings
 	isScriptError(error: Error): boolean
 	maybeLiftError(error: Error): Error

--- a/packages/core/src/runtime/ITest.ts
+++ b/packages/core/src/runtime/ITest.ts
@@ -5,7 +5,7 @@ import { Step } from './Step'
 import { CancellationToken } from '../utils/CancellationToken'
 import { ScreenshotOptions } from 'puppeteer'
 import { TestSettings } from './Settings'
-import { Looper } from '../Runner'
+import { Looper } from '../Looper'
 
 export interface ITest {
 	settings: TestSettings

--- a/packages/core/src/runtime/ITest.ts
+++ b/packages/core/src/runtime/ITest.ts
@@ -5,6 +5,7 @@ import { Step } from './Step'
 import { CancellationToken } from '../utils/CancellationToken'
 import { ScreenshotOptions } from 'puppeteer'
 import { TestSettings } from './Settings'
+import { Looper } from '../Runner'
 
 export interface ITest {
 	settings: TestSettings
@@ -19,7 +20,11 @@ export interface ITest {
 	cancel(): Promise<void>
 	beforeRun(): Promise<void>
 	run(iteration?: number): Promise<void>
-	runWithCancellation(iteration: number, cancelToken: CancellationToken): Promise<void>
+	runWithCancellation(
+		iteration: number,
+		cancelToken: CancellationToken,
+		looper: Looper,
+	): Promise<void>
 	runStep(
 		testObserver: TestObserver,
 		browser: Browser<Step>,

--- a/packages/core/src/runtime/Settings.ts
+++ b/packages/core/src/runtime/Settings.ts
@@ -234,6 +234,11 @@ export interface TestSettings {
 	 * The list of Chromium flags can be found at https://peter.sh/experiments/chromium-command-line-switches/
 	 */
 	launchArgs?: string[]
+
+	/**
+	 * Define the loop count of the recovery step
+	 */
+	maxRecovery?: number
 }
 
 /**
@@ -250,6 +255,7 @@ export const DEFAULT_SETTINGS: ConcreteTestSettings = {
 	clearCache: false,
 	waitTimeout: 30,
 	responseTimeMeasurement: 'step',
+	maxRecovery: 0,
 	/**
 	 * by default, don't filter any console messages from the browser
 	 */

--- a/packages/core/src/runtime/Step.ts
+++ b/packages/core/src/runtime/Step.ts
@@ -12,6 +12,13 @@ import { ElementPresence } from './Settings'
  *     await browser.visit("https://example.com")
  *   })
  *
+ *   step.recovery("Step 2", async (browser: Browser) => {
+ *     // do stuff
+ *     return RecoveryOption.RETRY //retry step 2 (default)
+ *     return RecoveryOption.RESTART //restart step 1
+ *     return RecoveryOption.ERROR //throw an error
+ *   })
+ *
  *   step("Step 2", async (browser: Browser) => {})
  *
  *   step("Step 3", async (browser: Browser) => {})

--- a/packages/core/src/runtime/Step.ts
+++ b/packages/core/src/runtime/Step.ts
@@ -118,9 +118,9 @@ export type StepRecoveryObject = {
 }
 
 /**
- * The `RecoveryOption` represents action which we will do after the recovery step has finished
+ * The `RecoveryOption` represents an action which we will do after the recovery step has finished
  * ```
- * RETRY: retry the step failed
+ * RETRY: retry the failed step
  * RESTART: re-run the first step
  * ERROR: throw an error
  * ```

--- a/packages/core/src/runtime/Step.ts
+++ b/packages/core/src/runtime/Step.ts
@@ -14,9 +14,9 @@ import { ElementPresence } from './Settings'
  *
  *   step.recovery("Step 2", async (browser: Browser) => {
  *     // do stuff
- *     return RecoveryOption.RETRY //retry step 2 (default)
- *     return RecoveryOption.RESTART //restart step 1
- *     return RecoveryOption.ERROR //throw an error
+ *     return RecoverWith.RETRY //retry step 2 (default)
+ *     return RecoverWith.RESTART //restart step 1
+ *     return RecoverWith.CONTINUE //continue next step
  *   })
  *
  *   step("Step 2", async (browser: Browser) => {})
@@ -85,6 +85,7 @@ export type StepOptions = {
 	skip?: boolean
 	waitTimeout?: number
 	waitUntil?: ElementPresence
+	maxRecovery?: number
 }
 
 export function extractOptionsAndCallback(args: any[]): [Partial<StepOptions>, TestFn] {
@@ -114,21 +115,24 @@ export function extractOptionsAndCallback(args: any[]): [Partial<StepOptions>, T
  */
 export type StepFunction<T> = (driver: Browser, data?: T) => Promise<void>
 export type StepRecoveryObject = {
-	[name: string]: Step
+	[name: string]: {
+		recoveryStep: Step
+		loopCount: number
+	}
 }
 
 /**
- * The `RecoveryOption` represents an action which we will do after the recovery step has finished
+ * The `RecoverWith` represents an action which we will do after the recovery step has finished
  * ```
  * RETRY: retry the failed step
  * RESTART: re-run the first step
- * ERROR: throw an error
+ * CONTINUE: continue next step
  * ```
  */
-export enum RecoveryOption {
+export enum RecoverWith {
 	RETRY = 'retry',
 	RESTART = 'restart',
-	ERROR = 'error',
+	CONTINUE = 'continue',
 }
 
 /**
@@ -149,6 +153,8 @@ export function normalizeStepOptions(stepOpts: StepOptions): StepOptions {
 		stepOpts.waitTimeout = stepOpts.waitTimeout / 1e3
 	} else if (Number(stepOpts.waitTimeout) === 0) {
 		stepOpts.waitTimeout = 30
+	} else if (Number(stepOpts.maxRecovery) === 0) {
+		stepOpts.maxRecovery = 1
 	}
 
 	return stepOpts

--- a/packages/core/src/runtime/Step.ts
+++ b/packages/core/src/runtime/Step.ts
@@ -83,7 +83,7 @@ export type StepOptions = {
 export function extractOptionsAndCallback(args: any[]): [Partial<StepOptions>, TestFn] {
 	if (args.length === 0) return [{ pending: true }, () => Promise.resolve()]
 	if (args.length === 1) {
-		return [{}, args[0]]
+		return [{}, args[0] as TestFn]
 	} else if (args.length === 2) {
 		const [options, fn] = args as [StepOptions, TestFn]
 		return [options, fn]
@@ -106,6 +106,23 @@ export function extractOptionsAndCallback(args: any[]): [Partial<StepOptions>, T
  * ```
  */
 export type StepFunction<T> = (driver: Browser, data?: T) => Promise<void>
+export type StepRecoveryObject = {
+	[name: string]: Step
+}
+
+/**
+ * The `RecoveryOption` represents action which we will do after the recovery step has finished
+ * ```
+ * RETRY: retry the step failed
+ * RESTART: re-run the first step
+ * ERROR: throw an error
+ * ```
+ */
+export enum RecoveryOption {
+	RETRY = 'retry',
+	RESTART = 'restart',
+	ERROR = 'error',
+}
 
 /**
  * @internal

--- a/packages/core/src/runtime/Step.ts
+++ b/packages/core/src/runtime/Step.ts
@@ -27,6 +27,7 @@ step.once = (name: string, ...optionsOrFn: any[]) => {}
 step.if = (condition: ConditionFn, name: string, ...optionsOrFn: any[]) => {}
 step.unless = (condition: ConditionFn, name: string, ...optionsOrFn: any[]) => {}
 step.skip = (name: string, ...optionsOrFn: any[]) => {}
+step.recovery = (name: string, ...optionsOrFn: any[]) => {}
 
 export interface StepBase {
 	(stepName: string, options: StepOptions, testFn: TestFn): void
@@ -60,6 +61,11 @@ export interface StepExtended extends StepBase {
 	 * Creates a conditional step, which will skip this test
 	 */
 	skip: StepBase
+
+	/**
+	 * Creates a recovery step
+	 */
+	recovery: StepBase
 }
 
 export type StepDefinition = (name: string, fn: TestFn) => Promise<any>

--- a/packages/core/src/runtime/Test.spec.ts
+++ b/packages/core/src/runtime/Test.spec.ts
@@ -70,6 +70,7 @@ describe('Test', () => {
 			extraHTTPHeaders: {},
 			launchArgs: [],
 			viewport: null,
+			maxRecovery: 0,
 		}
 		expect(test.settings).toEqual(defaultSettings)
 	})

--- a/packages/core/src/runtime/Test.ts
+++ b/packages/core/src/runtime/Test.ts
@@ -195,11 +195,13 @@ export default class Test implements ITest {
 			const callRecovery = async (step: Step): Promise<boolean> => {
 				const recoveryStep = this.recoverySteps[step.name]
 				if (!recoveryStep) return false
-
-				const result = await recoveryStep.fn.call(null, browser)
-				if (result === RecoveryOption.ERROR) return false
-
-				if (result === RecoveryOption.RESTART) this.stepCount = 0
+				try {
+					const result = await recoveryStep.fn.call(null, browser)
+					if (result === RecoveryOption.ERROR) return false
+					if (result === RecoveryOption.RESTART) this.stepCount = 0
+				} catch (err) {
+					return false
+				}
 				this.failed = false
 				return true
 			}

--- a/packages/core/src/runtime/Test.ts
+++ b/packages/core/src/runtime/Test.ts
@@ -204,7 +204,7 @@ export default class Test implements ITest {
 			const callRecovery = async (step: Step): Promise<boolean> => {
 				const { recoveryStep, loopCount } = this.recoverySteps[step.name]
 				const { maxRecovery } = this.settings
-				const settingRecoverCount = loopCount !== -1 ? loopCount : maxRecovery || 1
+				const settingRecoverCount = loopCount || maxRecovery || 1
 				if (!recoveryStep || this.recoveryCount >= settingRecoverCount) return false
 				this.recoveryCount += 1
 				try {

--- a/packages/core/src/runtime/Test.ts
+++ b/packages/core/src/runtime/Test.ts
@@ -14,7 +14,7 @@ import { AnyErrorData, EmptyErrorData, AssertionErrorData } from './errors/Types
 import { StructuredError } from '../utils/StructuredError'
 
 import { Step, ConditionFn, StepRecoveryObject, RecoverWith } from './Step'
-import { Looper } from '../Runner'
+import { Looper } from '../Looper'
 
 import { CancellationToken } from '../utils/CancellationToken'
 

--- a/packages/core/src/runtime/Test.ts
+++ b/packages/core/src/runtime/Test.ts
@@ -175,16 +175,18 @@ export default class Test implements ITest {
 
 			const callCondition = (step: Step): boolean => {
 				const { once, skip, pending } = step.options
-				if (once || skip || pending) this.stepCount += 1
 				if (pending) {
 					console.log(`(Pending) ${step.name}`)
+					this.stepCount += 1
 					return false
 				}
 				if (once && iteration > 1) {
+					this.stepCount += 1
 					return false
 				}
 				if (skip) {
 					console.log(`Skip test ${step.name}`)
+					this.stepCount += 1
 					return false
 				}
 				return true

--- a/packages/core/src/runtime/Test.ts
+++ b/packages/core/src/runtime/Test.ts
@@ -204,8 +204,8 @@ export default class Test implements ITest {
 			const callRecovery = async (step: Step): Promise<boolean> => {
 				const { recoveryStep, loopCount } = this.recoverySteps[step.name]
 				const { maxRecovery } = this.settings
-				const settingRecoverCount = loopCount || maxRecovery || 1
-				if (!recoveryStep || this.recoveryCount >= settingRecoverCount) return false
+				const settingRecoveryCount = loopCount || maxRecovery || 1
+				if (!recoveryStep || this.recoveryCount >= settingRecoveryCount) return false
 				this.recoveryCount += 1
 				try {
 					const result = await recoveryStep.fn.call(null, browser)

--- a/packages/core/src/runtime/Test.ts
+++ b/packages/core/src/runtime/Test.ts
@@ -194,6 +194,7 @@ export default class Test implements ITest {
 
 			const callRecovery = async (step: Step): Promise<boolean> => {
 				const recoveryStep = this.recoverySteps[step.name]
+				delete this.recoverySteps[step.name] // step recovery should be run 1 time
 				if (!recoveryStep) return false
 				try {
 					const result = await recoveryStep.fn.call(null, browser)

--- a/packages/element/index.ts
+++ b/packages/element/index.ts
@@ -110,3 +110,8 @@ export { step, TestFn, StepFunction, StepOptions } from '@flood/element-core'
  * @docPage DSL
  */
 export { suite } from '@flood/element-core'
+
+/**
+ * @docPage helpers
+ */
+export { RecoveryOption } from '@flood/element-core'

--- a/packages/element/index.ts
+++ b/packages/element/index.ts
@@ -114,4 +114,4 @@ export { suite } from '@flood/element-core'
 /**
  * @docPage helpers
  */
-export { RecoveryOption } from '@flood/element-core'
+export { RecoverWith } from '@flood/element-core'


### PR DESCRIPTION
### What does it do?
The idea behind this would be to declare a step which runs when any step fails, as a sort of catch-all. This could be used when the state of a page is not as expected, or authentication fails requiring starting at step 1 again. We could take this further and do something like this:

```ts
// Step 1 recovery
	step.recovery('Step 1', async browser => {
		//do stuff
		return RecoveryOption.RETRY
	})

	step('Step 1', async browser => {
		//do stuff
	})
```
resolve #70 