### PR TITLE
Fix: Handle multiple tabs that contain frame

### DIFF
--- a/examples/internet-herokuapp/33-Multiple_Windows.ts
+++ b/examples/internet-herokuapp/33-Multiple_Windows.ts
@@ -11,42 +11,39 @@ export const settings: TestSettings = {
 	stepDelay: 2,
 	waitTimeout: 60,
 	screenshotOnFailure: true,
-	DOMSnapshotOnFailure: true
+	DOMSnapshotOnFailure: true,
 }
 
 /**
  * Author: Antonio Jimenez : antonio@flood.io
  * The internet - heroku App
  * @version 1.1
-*/
+ */
 
 const URL = 'https://the-internet.herokuapp.com'
 
 export default () => {
-
 	step('Test: 01 - Homepage', async browser => {
-
 		await browser.visit(URL)
 		await browser.wait(Until.elementIsVisible(By.css('#content > h1')))
 		let pageTextVerify = By.visibleText('Welcome to the-internet')
 		await browser.wait(Until.elementIsVisible(pageTextVerify))
-
 	})
 
 	step('Test: 02 - Multiple Windows', async browser => {
-
-		await browser.visit(URL+'/windows')
+		await browser.visit(URL + '/windows')
 		await browser.wait(Until.elementIsVisible(By.css('#content > div > h3')))
 		let pageTextVerify = By.visibleText('Opening a new window')
 		await browser.wait(Until.elementIsVisible(pageTextVerify))
-
 	})
 
 	step('Test: 03 - Open a new Tab', async browser => {
-
 		let linkHref = await browser.findElement(By.css('#content > div > a'))
 		await linkHref.click()
-
+		await browser.waitForNewPage()
+		let pageTextVerify = By.visibleText('New Window')
+		await browser.wait(Until.elementIsVisible(pageTextVerify))
+		const pages = await browser.pages
+		assert.strictEqual(pages.length, 2, 'There should be 2 windows')
 	})
-
 }

--- a/packages/core/src/runtime/Browser.ts
+++ b/packages/core/src/runtime/Browser.ts
@@ -66,10 +66,16 @@ export class Browser<T> implements BrowserInterface {
 
 		this.newPageCallback = resolve => {
 			this.client.browser.once('targetcreated', async target => {
-				const newPage = await target.page()
-				this.client.page = newPage
-				await newPage.bringToFront()
-				resolve(newPage)
+				if (target.type() === 'page') {
+					const newPage = await target.page()
+					this.client.page = newPage
+					await newPage.bringToFront()
+					resolve(newPage)
+				} else {
+					this.newPagePromise = new Promise(resolve => {
+						this.newPageCallback(resolve)
+					})
+				}
 			})
 		}
 


### PR DESCRIPTION
- Fix: Cannot switch to a new tab if the current tab contains a frame
- Update the example for handling multiple tabs