### PR TITLE
[FLO-1756] Element - More example scripts - frames

### DIFF
--- a/examples/flood-io.ts
+++ b/examples/flood-io.ts
@@ -50,14 +50,22 @@ export default () => {
 		async browser => {
 			await browser.visit(`${URL}/pricing`)
 
+			// Until.titleDoesNotContain(title: string)
 			await browser.wait(Until.titleDoesNotContain('What is Flood'))
 			const title = await browser.title()
 			assert(!title.includes('What is Flood'), 'The new title should not include the old title')
 
-			const getStartedButton = await browser.findElement(By.partialLinkText('Get Started'))
+			const getStartedButtonEl = By.partialLinkText('Get Started')
+			// Until.elementsLocated(selectorOrLocator: NullableLocatable, desiredCount = 2)
+			await browser.wait(Until.elementsLocated(getStartedButtonEl, 2))
+			const getStartedButton = await browser.findElement(getStartedButtonEl)
 			await browser.click(getStartedButton)
+
+			// Until.urlDoesNotContain(url: string)
 			await browser.wait(Until.urlDoesNotContain('pricing'))
 			const heading = By.css('h3')
+
+			// Until.elementsLocated(selectorOrLocator: NullableLocatable, desiredCount = 1)
 			await browser.wait(Until.elementsLocated(heading))
 			const headingText = await (await browser.findElement(heading)).text()
 			assert.strictEqual(

--- a/examples/flood-io.ts
+++ b/examples/flood-io.ts
@@ -1,0 +1,45 @@
+import { step, Until, By, TestSettings } from '@flood/element'
+import assert from 'assert'
+
+/**
+ * Author: Hong La : hong@flood.io
+ * Flood IO
+ */
+
+export const settings: TestSettings = {
+	clearCache: false,
+	disableCache: false,
+	clearCookies: false,
+	loopCount: 1,
+	duration: 1,
+	actionDelay: 2,
+	stepDelay: 2,
+	waitTimeout: 60,
+	screenshotOnFailure: true,
+}
+
+const URL = 'https://flood.io'
+
+export default () => {
+	step('Test: Go to flood.io and use Until.titleContains and Until.urlContains', async browser => {
+		await browser.visit(URL)
+		// Until.titleContains example
+		await browser.wait(Until.titleContains('Flood'))
+		const floodTitle = await browser.title()
+		assert(
+			floodTitle === 'Scalable software starts here - Flood',
+			'The title of Flood page should be correct',
+		)
+		const whyFloodEl = await browser.findElement(By.visibleText('Why Flood?'))
+		await whyFloodEl.click()
+		// Util.urlContains example
+		await browser.wait(Until.urlContains('what-is'))
+		await browser.wait(Until.elementIsVisible(By.css('h1.headline-2')))
+		const headingEl = await browser.findElement(By.tagName('h1'))
+		const headingText = await headingEl.text()
+		assert(
+			headingText === 'Flood is an easy to use load testing platform',
+			'The heading should be correct',
+		)
+	})
+}

--- a/examples/flood-io.ts
+++ b/examples/flood-io.ts
@@ -23,6 +23,7 @@ const URL = 'https://flood.io'
 export default () => {
 	step('Test: Go to flood.io and use Until.titleContains and Until.urlContains', async browser => {
 		await browser.visit(URL)
+
 		// Until.titleContains example
 		await browser.wait(Until.titleContains('Flood'))
 		const floodTitle = await browser.title()
@@ -32,6 +33,7 @@ export default () => {
 		)
 		const whyFloodEl = await browser.findElement(By.visibleText('Why Flood?'))
 		await whyFloodEl.click()
+
 		// Util.urlContains example
 		await browser.wait(Until.urlContains('what-is'))
 		await browser.wait(Until.elementIsVisible(By.css('h1.headline-2')))
@@ -42,4 +44,27 @@ export default () => {
 			'The heading should be correct',
 		)
 	})
+
+	step(
+		'Test: Go to Pricing and check Title, URL by Until.titleDoesNotContain, Until.urlDoesNotContain',
+		async browser => {
+			await browser.visit(`${URL}/pricing`)
+
+			await browser.wait(Until.titleDoesNotContain('What is Flood'))
+			const title = await browser.title()
+			assert(!title.includes('What is Flood'), 'The new title should not include the old title')
+
+			const getStartedButton = await browser.findElement(By.partialLinkText('Get Started'))
+			await browser.click(getStartedButton)
+			await browser.wait(Until.urlDoesNotContain('pricing'))
+			const heading = By.css('h3')
+			await browser.wait(Until.elementsLocated(heading))
+			const headingText = await (await browser.findElement(heading)).text()
+			assert.strictEqual(
+				headingText,
+				'Ready to get started?',
+				'The heading of Flood sign up page should be correct',
+			)
+		},
+	)
 }

--- a/examples/mozilla-demos.ts
+++ b/examples/mozilla-demos.ts
@@ -1,0 +1,39 @@
+import { step, Until, By, TestSettings } from '@flood/element'
+import assert from 'assert'
+
+/**
+ * Author: Hong La : hong@flood.io
+ * Mozilla Demos
+ */
+
+export const settings: TestSettings = {
+	clearCache: false,
+	disableCache: false,
+	clearCookies: false,
+	loopCount: 1,
+	duration: 1,
+	actionDelay: 2,
+	stepDelay: 2,
+	waitTimeout: 60,
+	screenshotOnFailure: true,
+}
+
+const URL =
+	'https://mdn.mozillademos.org/en-US/docs/Web/API/Element/dblclick_event$samples/Examples'
+
+export default () => {
+	step('Test: Double Click Event', async browser => {
+		await browser.visit(URL)
+		const pageTextVerify = By.visibleText('My Card')
+		await browser.wait(Until.elementIsVisible(pageTextVerify))
+		const asideEl = await browser.findElement(By.tagName('aside'))
+		await browser.doubleClick(asideEl)
+		const asideLargeClass = await asideEl.getAttribute('class')
+		assert(
+			asideLargeClass.toLowerCase() === 'large',
+			'The aside element should have large class after be dblclicked',
+		)
+		await browser.wait(3)
+		await browser.takeScreenshot()
+	})
+}

--- a/examples/the-internet-more-examples/frames.ts
+++ b/examples/the-internet-more-examples/frames.ts
@@ -60,11 +60,20 @@ export default () => {
 				'The active element tagname should be frameset',
 			)
 
-			// Example of TargetLocator.frame()
+			// Example of TargetLocator.frame(ElementHandle)
 			await browser.switchTo().frame(bottomFrameEl)
 			const bottomBody = await browser.findElement(By.tagName('body'))
 			const bottomText = await bottomBody.text()
-			assert(bottomText === 'BOTTOM', 'The inner text of the bottom frame is BOTTOM')
+			assert(bottomText === 'BOTTOM', 'The inner text of the bottom frame should be BOTTOM')
+
+			// TargetLocator.frame(id|name)
+			await browser.switchTo().frame('frame-top')
+			await browser.wait(Until.ableToSwitchToFrame('frame-right'))
+			await browser.switchTo().frame('frame-right')
+			const rightBody = await browser.findElement(By.tagName('body'))
+			const rightText = await rightBody.text()
+
+			assert(rightText === 'RIGHT', 'The inner text of the right frame should be RIGHT')
 		},
 	)
 
@@ -108,6 +117,6 @@ export default () => {
 			'The aside should have large class after be dblclicked',
 		)
 
-		await browser.wait(1)
+		await browser.wait(5)
 	})
 }

--- a/examples/the-internet-more-examples/frames.ts
+++ b/examples/the-internet-more-examples/frames.ts
@@ -9,7 +9,7 @@ export const settings: TestSettings = {
 	duration: 1,
 	actionDelay: 2,
 	stepDelay: 2,
-	waitTimeout: 600,
+	waitTimeout: 60,
 	screenshotOnFailure: true,
 }
 
@@ -20,6 +20,8 @@ export const settings: TestSettings = {
 
 const URL = 'https://the-internet.herokuapp.com'
 const floodIOURL = 'https://flood.io'
+const mozillaDblClickURL =
+	'https://mdn.mozillademos.org/en-US/docs/Web/API/Element/dblclick_event$samples/Examples'
 
 const goToFramesPage = async browser => {
 	await browser.visit(`${URL}/frames`)
@@ -89,5 +91,23 @@ export default () => {
 			headingText === 'Flood is an easy to use load testing platform',
 			'The heading should be correct',
 		)
+	})
+
+	step('Test: Double Click Event', async browser => {
+		await browser.switchTo().defaultContent()
+		await browser.visit(mozillaDblClickURL)
+
+		const pageTextVerify = By.visibleText('My Card')
+		await browser.wait(Until.elementIsVisible(pageTextVerify))
+
+		const asideEl = await browser.findElement(By.tagName('aside'))
+		await browser.doubleClick(asideEl)
+		const asideLargeClass = await asideEl.getAttribute('class')
+		assert(
+			asideLargeClass.toLowerCase() === 'large',
+			'The aside should have large class after be dblclicked',
+		)
+
+		await browser.wait(1)
 	})
 }

--- a/examples/the-internet-more-examples/frames.ts
+++ b/examples/the-internet-more-examples/frames.ts
@@ -39,18 +39,22 @@ export default () => {
 		await goToFramesPage(browser)
 	})
 
-	step('Test: Go to Nested Frame using Until.ableToSwitchToFrame', async browser => {
-		const nestedFrameEl = await browser.findElement(By.partialLinkText('Nested Frames'))
-		await nestedFrameEl.click()
+	step(
+		'Test: Go to Nested Frame, use Until.ableToSwitchToFrame and find Element with By.nameAttr',
+		async browser => {
+			const nestedFrameEl = await browser.findElement(By.partialLinkText('Nested Frames'))
+			await nestedFrameEl.click()
 
-		await browser.wait(Until.ableToSwitchToFrame('frame-bottom'))
+			await browser.wait(Until.ableToSwitchToFrame('frame-bottom'))
 
-		const bottomFrameEl = await browser.findElement(By.nameAttr('frame-bottom'))
-		await browser.switchTo().frame(bottomFrameEl)
-		const bottomBody = await browser.findElement(By.tagName('body'))
-		const bottomText = await bottomBody.text()
-		assert(bottomText === 'BOTTOM', 'The inner text of the bottom frame is BOTTOM')
-	})
+			// An example of using By.nameAttr
+			const bottomFrameEl = await browser.findElement(By.nameAttr('frame-bottom'))
+			await browser.switchTo().frame(bottomFrameEl)
+			const bottomBody = await browser.findElement(By.tagName('body'))
+			const bottomText = await bottomBody.text()
+			assert(bottomText === 'BOTTOM', 'The inner text of the bottom frame is BOTTOM')
+		},
+	)
 
 	step('Test: Go to flood.io and use Until.titleContains and Until.urlContains', async browser => {
 		await browser.switchTo().defaultContent()

--- a/examples/the-internet-more-examples/frames.ts
+++ b/examples/the-internet-more-examples/frames.ts
@@ -1,0 +1,69 @@
+import { step, TestSettings, Until, By, Locator } from '@flood/element'
+import assert from 'assert'
+
+export const settings: TestSettings = {
+	clearCache: false,
+	disableCache: false,
+	clearCookies: false,
+	loopCount: 1,
+	duration: 1,
+	actionDelay: 2,
+	stepDelay: 2,
+	waitTimeout: 600,
+	screenshotOnFailure: true,
+}
+
+/**
+ * Author: Hong La : hong@flood.io
+ * The Internet - Heroku App
+ */
+
+const URL = 'https://the-internet.herokuapp.com'
+
+const goToFramesPage = async browser => {
+	await browser.visit(`${URL}/frames`)
+	const pageTextVerify: Locator = By.visibleText('Frames')
+	await browser.wait(Until.elementIsVisible(pageTextVerify))
+}
+
+export default () => {
+	step('Test: Go to the homepage', async browser => {
+		await browser.visit(URL)
+		await browser.wait(Until.elementIsVisible(By.css('#content > h1')))
+		const pageTextVerify: Locator = By.visibleText('Welcome to the-internet')
+		await browser.wait(Until.elementIsVisible(pageTextVerify))
+	})
+
+	step('Test: Go to Frames page', async browser => {
+		await goToFramesPage(browser)
+	})
+
+	step('Test: Go to Nested Frame using Until.ableToSwitchToFrame', async browser => {
+		const nestedFrameEl = await browser.findElement(By.partialLinkText('Nested Frames'))
+		await nestedFrameEl.click()
+
+		await browser.wait(Until.ableToSwitchToFrame('frame-bottom'))
+
+		const bottomFrameEl = await browser.findElement(By.nameAttr('frame-bottom'))
+		await browser.switchTo().frame(bottomFrameEl)
+		const bottomBody = await browser.findElement(By.tagName('body'))
+		const bottomText = await bottomBody.text()
+		assert(bottomText === 'BOTTOM', 'The inner text of the bottom frame is BOTTOM')
+	})
+
+	step('Test: Go back to Frames page', async browser => {
+		await browser.switchTo().defaultContent()
+		await goToFramesPage(browser)
+	})
+
+	step('Test: Go to iFrame and use Until.titleContains and Until.urlContains', async browser => {
+		const iFrameEl = await browser.findElement(By.partialLinkText('iFrame'))
+		await iFrameEl.click()
+
+		await browser.wait(Until.titleContains('The Internet'))
+
+		const titleEl = await browser.findElement(By.css('h3'))
+		const titleText = await titleEl.text()
+		assert(titleText.includes('TinyMCE'), 'The title of the page should include text TinyMCE')
+	})
+}

--- a/examples/the-internet-more-examples/frames.ts
+++ b/examples/the-internet-more-examples/frames.ts
@@ -19,6 +19,7 @@ export const settings: TestSettings = {
  */
 
 const URL = 'https://the-internet.herokuapp.com'
+const floodIOURL = 'https://flood.io'
 
 const goToFramesPage = async browser => {
 	await browser.visit(`${URL}/frames`)
@@ -30,7 +31,7 @@ export default () => {
 	step('Test: Go to the homepage', async browser => {
 		await browser.visit(URL)
 		await browser.wait(Until.elementIsVisible(By.css('#content > h1')))
-		const pageTextVerify: Locator = By.visibleText('Welcome to the-internet')
+		const pageTextVerify = By.visibleText('Welcome to the-internet')
 		await browser.wait(Until.elementIsVisible(pageTextVerify))
 	})
 
@@ -51,19 +52,26 @@ export default () => {
 		assert(bottomText === 'BOTTOM', 'The inner text of the bottom frame is BOTTOM')
 	})
 
-	step('Test: Go back to Frames page', async browser => {
+	step('Test: Go to flood.io and use Until.titleContains and Until.urlContains', async browser => {
 		await browser.switchTo().defaultContent()
-		await goToFramesPage(browser)
-	})
 
-	step('Test: Go to iFrame and use Until.titleContains and Until.urlContains', async browser => {
-		const iFrameEl = await browser.findElement(By.partialLinkText('iFrame'))
-		await iFrameEl.click()
+		await browser.visit(floodIOURL)
+		await browser.wait(Until.titleContains('Flood'))
+		const floodTitle = await browser.title()
+		assert(
+			floodTitle === 'Scalable software starts here - Flood',
+			'The title of Flood page should be correct',
+		)
 
-		await browser.wait(Until.titleContains('The Internet'))
-
-		const titleEl = await browser.findElement(By.css('h3'))
-		const titleText = await titleEl.text()
-		assert(titleText.includes('TinyMCE'), 'The title of the page should include text TinyMCE')
+		const whyFloodEl = await browser.findElement(By.visibleText('Why Flood?'))
+		await whyFloodEl.click()
+		await browser.wait(Until.urlContains('what-is-flood'))
+		await browser.wait(Until.elementIsVisible(By.css('h1.headline-2')))
+		const headingEl = await browser.findElement(By.tagName('h1'))
+		const headingText = await headingEl.text()
+		assert(
+			headingText === 'Flood is an easy to use load testing platform',
+			'The heading should be correct',
+		)
 	})
 }

--- a/examples/the-internet-more-examples/frames.ts
+++ b/examples/the-internet-more-examples/frames.ts
@@ -45,10 +45,20 @@ export default () => {
 			const nestedFrameEl = await browser.findElement(By.partialLinkText('Nested Frames'))
 			await nestedFrameEl.click()
 
+			// Until.ableToSwitchToFrame example
 			await browser.wait(Until.ableToSwitchToFrame('frame-bottom'))
 
 			// An example of using By.nameAttr
 			const bottomFrameEl = await browser.findElement(By.nameAttr('frame-bottom'))
+			// Example of TargetLocator.activeElement
+			const activeEl = await browser.switchTo().activeElement()
+			const activeElTagName = await activeEl.tagName()
+			assert(
+				activeElTagName.toLowerCase() === 'frameset',
+				'The active element tagname should be frameset',
+			)
+
+			// Example of TargetLocator.frame()
 			await browser.switchTo().frame(bottomFrameEl)
 			const bottomBody = await browser.findElement(By.tagName('body'))
 			const bottomText = await bottomBody.text()
@@ -60,6 +70,7 @@ export default () => {
 		await browser.switchTo().defaultContent()
 
 		await browser.visit(floodIOURL)
+		// Until.titleContains example
 		await browser.wait(Until.titleContains('Flood'))
 		const floodTitle = await browser.title()
 		assert(
@@ -69,6 +80,7 @@ export default () => {
 
 		const whyFloodEl = await browser.findElement(By.visibleText('Why Flood?'))
 		await whyFloodEl.click()
+		// Util.urlContains example
 		await browser.wait(Until.urlContains('what-is-flood'))
 		await browser.wait(Until.elementIsVisible(By.css('h1.headline-2')))
 		const headingEl = await browser.findElement(By.tagName('h1'))


### PR DESCRIPTION
This PR includes the example scripts below:
```
Until.ableToSwitchToFrame(frame: Locator)
Until.titleContains(title: string)
Until.urlContains(url: string)

By.nameAttr(value: string)

ElementHandle.clear()
ElementHandle.type(text: string)
ElementHandle.blur()
ElementHandle.highlight()

TargetLocator.activeElement()
TargetLocator.frame(id: number | string | ElementHandle)

Browser.doubleClick(locatable: NullableLocatable, options?: ClickOptions)
```