### PR TITLE
fix: Class extends value undefined is not a constructor or null (class TracingObserver extends NetworkRecordingTestObserver)

### DIFF
--- a/packages/flood-runner/package.json
+++ b/packages/flood-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@flood/element-flood-runner",
-	"version": "1.3.0-beta.4",
+	"version": "1.3.0-beta.19",
 	"description": "Flood runner for Element",
 	"author": "Ivan Vanderbyl <ivanvanderbyl@gmail.com>",
 	"homepage": "https://github.com/flood-io/element#readme",
@@ -22,7 +22,7 @@
 		"url": "https://github.com/flood-io/element/issues"
 	},
 	"dependencies": {
-		"@flood/element-core": "^1.2.3-beta.4",
+		"@flood/element-core": "^1.3.0-beta.19",
 		"@flood/node-influx": "^5.0.9",
 		"find-root": "^1.1.0",
 		"winston": "^3.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1141,50 +1141,6 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@flood/element-compiler@^1.2.3":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@flood/element-compiler/-/element-compiler-1.2.3.tgz#4623de3a109626080df30e98874edf7d2482ab00"
-  integrity sha512-ONoM3vh2APUNbuwrbeq6nTyOCjaPjurJakCmYLXlt6QnqqtsK/L8nQGyBtzqea+eSYgHPhsIVGCppgG+puHEyw==
-  dependencies:
-    find-root "^1.1.0"
-    memory-fs "^0.5.0"
-    mkdirp "^1.0.3"
-    ts-loader "^6.2.1"
-    tsconfig-paths-webpack-plugin "^3.2.0"
-    typescript "3.7.4"
-    webpack "^4.41.5"
-    webpackbar "^4.0.0"
-
-"@flood/element-core@^1.2.3-beta.4":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@flood/element-core/-/element-core-1.2.3.tgz#4b79b0dc029546302368eba381ebfe39bcd741ef"
-  integrity sha512-yGoirsdZ/qyYPbPH5ol/N9nG5svjAaebLQ9z+WjKbYWsxNoRLGg6FIF6DkDi7PFb9vFjEaHGembVqtfLR3Zuaw==
-  dependencies:
-    "@flood/element-compiler" "^1.2.3"
-    "@types/faker" "^4.1.9"
-    "@types/node" "12.7.4"
-    "@types/puppeteer" "^2.0.1"
-    assert "^1.4.1"
-    comment-parser "^0.5.0"
-    csv "^3.1.0"
-    d3-array "^1.2.0"
-    diff "^3.3.0"
-    faker "^4.1.0"
-    find-root "^1.1.0"
-    fs-extra "^4.0.2"
-    knuth-shuffle "^1.0.8"
-    ksuid "^1.2.0"
-    micromatch "^4.0.2"
-    puppeteer "^2.1.1"
-    recast "^0.13.0"
-    sanitize-filename "^1.6.1"
-    source-map "^0.7.0"
-    strftime "^0.10.0"
-    term-img "^2.1.0"
-    typedoc "^0.15.0"
-    vm2 "^3.5.2"
-    winston "^3.0.0"
-
 "@flood/node-influx@^5.0.9":
   version "5.0.9"
   resolved "https://registry.yarnpkg.com/@flood/node-influx/-/node-influx-5.0.9.tgz#ec3088341840a8ce1bfdb7f2ba0f1eebc0beab55"
@@ -12187,11 +12143,6 @@ vm-browserify@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.0.tgz#bd76d6a23323e2ca8ffa12028dc04559c75f9019"
   integrity sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==
-
-vm2@^3.5.2:
-  version "3.9.2"
-  resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.9.2.tgz#a4085d2d88a808a1b3c06d5478c2db3222a9cc30"
-  integrity sha512-nzyFmHdy2FMg7mYraRytc2jr4QBaUY3TEGe3q3bK8EgS9WC98wxn2jrPxS/ruWm+JGzrEIIeufKweQzVoQEd+Q==
 
 vm2@^3.9.1:
   version "3.9.1"


### PR DESCRIPTION
Package `flood-runner` is using an old version of `element-core` (version `1.2.3-beta.4`) which is incompatible with the current latest version `1.3.0-beta.19` (class `NetworkRecordingTestObserver` is not defined in version `1.2.3-beta.4`).

This PR update the version of `element-core` which `flood-runner` is using to the latest.
