### PR TITLE
chore: force all packages to have the same version + auto publish to brew

### DIFF
--- a/.github/workflows/lerna-beta.yml
+++ b/.github/workflows/lerna-beta.yml
@@ -9,7 +9,7 @@ on:
       - beta
 jobs:
   publish_release:
-    name: Publish NPM release
+    name: Publish release
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     runs-on: ubuntu-latest
     steps:
@@ -37,6 +37,8 @@ jobs:
       - name: 'Build all'
         run: yarn build
       - name: 'Publish beta to NPM'
-        run: yarn lerna publish --conventional-prerelease --dist-tag beta --yes --preid beta --include-merged-tags
+        run: yarn lerna publish --conventional-prerelease --dist-tag beta --yes --preid beta --include-merged-tags --force-publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: 'Publish beta to Homebrew'
+        run: yarn publish:brew

--- a/.github/workflows/lerna-stable.yml
+++ b/.github/workflows/lerna-stable.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish_release:
-    name: Publish NPM release
+    name: Publish release
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     runs-on: ubuntu-latest
     steps:
@@ -35,6 +35,8 @@ jobs:
       - name: 'Build all'
         run: yarn build
       - name: 'Publish stable to NPM'
-        run: yarn lerna publish --conventional-graduate --dist-tag latest --yes
+        run: yarn lerna publish --conventional-graduate --dist-tag latest --yes --force-publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: 'Publish stable to Homebrew'
+        run: yarn publish:brew


### PR DESCRIPTION
- Add the flag `--force-publish` to the command `lerna publish` so that every package has its version bumped even when it was not modified
- Add the script for publishing the release to Homebrew from the workflows