### PR TITLE
fix: apply the setting's consoleFilter setting to Observer

### DIFF
--- a/packages/core/src/runtime/Observer.ts
+++ b/packages/core/src/runtime/Observer.ts
@@ -14,13 +14,11 @@ interface RequestEvent extends Event {
 }
 
 export default class Observer {
-	public consoleFilters: ConsoleMethod[] = []
-
 	private failedRequests: string[]
 	private requests: Set<string> = new Set()
 	private attached = false
 
-	constructor(private reporter: IReporter, public networkRecorder: NetworkRecorder) {}
+	constructor(private reporter: IReporter, public networkRecorder: NetworkRecorder, public consoleFilters: ConsoleMethod[] = []) {}
 
 	public attachToNetworkRecorder() {
 		if (this.attached) return

--- a/packages/core/src/runtime/Test.ts
+++ b/packages/core/src/runtime/Test.ts
@@ -211,7 +211,7 @@ export default class Test implements ITest {
 	): Promise<void> {
 		console.assert(this.client, `client is not configured in Test`)
 
-		const ctx = new Context()
+		const ctx = new Context(this.settings)
 
 		const testObserver = new ErrorObserver(
 			new LifecycleObserver(

--- a/packages/core/src/runtime/test-observers/Context.ts
+++ b/packages/core/src/runtime/test-observers/Context.ts
@@ -3,12 +3,15 @@ import { IReporter } from '../../Reporter'
 import { Test } from './testTypes'
 import NetworkRecorder from '../../network/Recorder'
 import NetworkObserver from '../Observer'
+import { ConcreteTestSettings, DEFAULT_SETTINGS } from '../Settings'
 
 export class Context {
 	public networkRecorder: NetworkRecorder
 	public observer: NetworkObserver
 
 	private attached = false
+
+	constructor(public settings: ConcreteTestSettings = DEFAULT_SETTINGS) {}
 
 	public attachTest(test: Test) {
 		if (this.attached) return
@@ -20,7 +23,7 @@ export class Context {
 
 	public attachToPage(reporter: IReporter, page: Page) {
 		this.networkRecorder = new NetworkRecorder(page)
-		this.observer = new NetworkObserver(reporter, this.networkRecorder)
+		this.observer = new NetworkObserver(reporter, this.networkRecorder, this.settings.consoleFilter)
 		this.observer.attachToNetworkRecorder()
 	}
 


### PR DESCRIPTION
Hi 👋 , It appears the `consoleFilter` setting is not being applied to the Observer, although it is being referenced. 

It appears we are not the only ones having this [issue](https://github.com/flood-io/element/issues/237). 