### PR TITLE
Bugfix: Element 1.3

### DIFF
--- a/packages/cli/src/cmd/run.ts
+++ b/packages/cli/src/cmd/run.ts
@@ -42,23 +42,21 @@ function setupDelayOverrides(
 	testSettingOverrides: TestSettings,
 ): TestSettings {
 	if (testSettingOverrides == null) testSettingOverrides = {}
-	const { actionDelay, stepDelay } = args
-	let convertedActionDelay = 0
-	let convertedStepDelay = 0
+	let { actionDelay, stepDelay } = args
 
-	if (typeof actionDelay === 'string' && actionDelay) {
-		convertedActionDelay = ms(actionDelay)
-	} else if (typeof actionDelay === 'number') {
-		convertedActionDelay = actionDelay
+	if (actionDelay) {
+		if (typeof actionDelay === 'string') {
+			actionDelay = ms(actionDelay)
+		}
+		testSettingOverrides.actionDelay = actionDelay
 	}
-	testSettingOverrides.actionDelay = convertedActionDelay > 0 ? convertedActionDelay : 0
 
-	if (typeof stepDelay === 'string' && stepDelay) {
-		convertedStepDelay = ms(stepDelay)
-	} else if (typeof stepDelay === 'number') {
-		convertedStepDelay = stepDelay
+	if (stepDelay) {
+		if (typeof stepDelay === 'string') {
+			stepDelay = ms(stepDelay)
+		}
+		testSettingOverrides.stepDelay = stepDelay
 	}
-	testSettingOverrides.stepDelay = convertedStepDelay > 0 ? convertedStepDelay : 0
 
 	if (args.fastForward) {
 		testSettingOverrides.stepDelay = 1000

--- a/packages/cli/src/utils/ConsoleReporter.ts
+++ b/packages/cli/src/utils/ConsoleReporter.ts
@@ -91,6 +91,7 @@ cause.stack: ${detail.causeStack}`)
 		debug('testScriptConsole', method, message)
 		if (method === 'log') method = 'info'
 		if (method === 'warning') method = 'warn'
-		;(this.logger as any)[method](`page console.${method}: ${message} ${optionalParams.join(' ')}`)
+		const consolMethod = this.logger[method] || console.info
+		consolMethod(`page console.${method}: ${message} ${optionalParams.join(' ')}`)
 	}
 }


### PR DESCRIPTION
Resolve those issues:
- https://spectrum.chat/flood/element/cannot-call-getcomponentdata-on-component~886b4dac-338b-4984-bd01-b74a5d6b1c74
- setting `actionDelay` and `stepDelay` does not work