### PR TITLE
fix: error publishing Element to Homebrew

### DIFF
--- a/.github/workflows/lerna-beta.yml
+++ b/.github/workflows/lerna-beta.yml
@@ -41,4 +41,8 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: 'Publish beta to Homebrew'
-        run: yarn publish:brew
+        uses: izumin5210/action-homebrew-tap@v1
+        with:
+          tap: izumin5210/homebrew-tools
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tap-token: ${{ secrets.TAP_GITHUB_TOKEN }}

--- a/.github/workflows/lerna-stable.yml
+++ b/.github/workflows/lerna-stable.yml
@@ -39,4 +39,8 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: 'Publish stable to Homebrew'
-        run: yarn publish:brew
+        uses: izumin5210/action-homebrew-tap@v1
+        with:
+          tap: izumin5210/homebrew-tools
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tap-token: ${{ secrets.TAP_GITHUB_TOKEN }}


### PR DESCRIPTION
Using https://github.com/marketplace/actions/homebrew-tap in both stable and beta workflows to publish the release to Homebrew

**Note:**  Before this PR get merged, `secrets.GITHUB_TOKEN` and `secrets.TAP_GITHUB_TOKEN` need to be set in the env