### PR TITLE
fix: some minor bugs

### DIFF
--- a/packages/cli/src/utils/flood.ts
+++ b/packages/cli/src/utils/flood.ts
@@ -145,7 +145,7 @@ export function countVUH(options: LaunchOptions, gridCount: number) {
 export async function authenticate(username: string): Promise<void> {
 	const token = Buffer.from(`${username}:`).toString('base64')
 	const res = await (
-		await fetch('https://api.flood.io/account', {
+		await fetch('https://api.flood.io/api/users/me', {
 			headers: {
 				Authorization: `Basic ${token}`,
 			},

--- a/packages/core/src/runtime/Test.ts
+++ b/packages/core/src/runtime/Test.ts
@@ -209,7 +209,8 @@ export default class Test implements ITest {
 					if (result) {
 						this.failed = false
 					} else {
-						throw Error('recovery step -> failed')
+						console.log('failed, bailing out of steps')
+						throw Error('test failed')
 					}
 				}
 


### PR DESCRIPTION
Fix the following things:
- Cannot authenticate with flood using an account member token
- Show error `recovery step -> failed` even when there's no recovery step