### PR TITLE
Update csv-parse dependency to fix vulnerability

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,7 @@
 		"@types/puppeteer": "^2.0.1",
 		"assert": "^1.4.1",
 		"comment-parser": "^0.5.0",
-		"csv": "^3.1.0",
+		"csv-parse": "^4.12.0",
 		"d3-array": "^1.2.0",
 		"diff": "^3.3.0",
 		"faker": "^4.1.0",


### PR DESCRIPTION
Hello!  This PR updates the CSV dependency to resolve [this upstream vulnerability](https://www.npmjs.com/advisories/1171).  Along the way, I realized that the entire `csv` module was a dependency, but only `csv-parse` was being used (`csv` includes `csv-parse` and a few others).  So this PR also swaps out `csv` for `csv-parse`.

There are no code changes required for this PR - it's a dependency only change.  