### PR TITLE
fix: handle fail exit code when running on local only

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Scaling up Element tests is easy on [Flood](https://flood.io), by launching hund
 - [4. Run a real Load Test on Flood](#4-run-a-real-load-test-on-flood)
 - [About](#about)
   - [What can I do with it?](#what-can-i-do-with-it)
-- [Getting Started](#getting-started)
+- [Do more with Element](#do-more-with-element)
 - [Contributing](#contributing)
 - [Reporting Issues](#reporting-issues)
 - [Authors](#authors)
@@ -131,11 +131,9 @@ For details of the available options see the [`element run`](./packages/cli/READ
 
 ## 4. Run a real Load Test on [Flood](https://flood.io)
 
-Now that you have a test script, upload it to [Flood](https://app.flood.io) as a new Stream and launch a Flood (a test).
+Now that you have a test script, upload it to [Flood](https://app.flood.io) as a [new Stream](https://guides.flood.io/scripting-and-tools/flood-element/getting-started-with-element#create-a-stream) and launch a Flood (a test).
 
-![Upload your script to Tricentis Flood](./packages/element/docs/examples/images/upload-script.png)
-
-Continue learning more Flood Element techniques by starting with our [API documentation](./packages/element/docs/SUMMARY.md). The main entry point to all tests is the [Browser](./packages/element/docs/api/Browser.md) class and a great place to get a feel for the capabilities of each test.
+Since Element version 1.3, you can [launch a flood directly from Element CLI](https://element.flood.io/docs/next/guides/cli#run-an-element-script-on-flood)
 
 ## About
 
@@ -148,7 +146,8 @@ Over the years, countless customers have mentioned that getting started with Loa
 - Measure your application's response time from different regions as experienced by your customers.
 - Create **realistic load scenarios** which stress test your network infrastructure without developing complex protocol level load test scripts.
 
-## Getting Started
+## Do more with Element
+Continue learning more Flood Element techniques by starting with our [API documentation](https://element.flood.io/docs/). The main entry point to all tests is the [Browser](https://element.flood.io/docs/1.0/api/browser) class and a great place to get a feel for the capabilities of each test.
 
 Visit <a aria-label="Element documentation" href="https://element.flood.io">https://element.flood.io</a> to view the documentation.
 
@@ -160,7 +159,7 @@ Please see our [CONTRIBUTING.md](/CONTRIBUTING.md).
 
 If you encounter any issues with the `@flood/element` project or Flood Element product, please [open an issue](https://github.com/flood-io/element/issues) on the GitHub project.
 
-If you're encountering issues with Flood itself, please contact Flood Support from within the Flood Dashboard.
+If you're encountering issues with Flood itself, please contact Flood Support from within the Flood Dashboard, [send us an email](mailto:support@flood.io) or [ask our community](https://spectrum.chat/flood).
 
 ## Authors
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -5,13 +5,22 @@ A tool for developing Flood Element test scripts.
 Install Element CLI on your own machine to quickly iterate the development of your Browser Level User test script.
 Once you're satisfied, upload it to [Tricentis Flood](https://flood.io) use it to generate 1000s of users of load in a full-scale load test.
 
-- [Installation](#installation)
-- [Getting started](#getting-started)
-- Commands
-  - [`element run`](#element-run)
-  - [`element plan`](#element-plan)
-  - [`element init`](#element-init)
-  - [`element generate`](#element-generate)
+- [Flood Element CLI](#flood-element-cli)
+  - [Installation](#installation)
+  - [Getting started](#getting-started)
+    - [`element run <file>`](#element-run-file)
+    - [`element plan <file> [options]`](#element-plan-file-options)
+    - [`element init [dir] [options]`](#element-init-dir-options)
+    - [`element generate <file>`](#element-generate-file)
+    - [`element generate config [file-name]`](#element-generate-config-file-name)
+    - [`element run`](#element-run)
+    - [`element run --config-file [path-to-config-file]`](#element-run---config-file-path-to-config-file)
+  - [Run an Element script on Flood](#run-an-element-script-on-flood)
+    - [`element flood authenticate <flood-api-token>`](#element-flood-authenticate-flood-api-token)
+    - [`element flood project ls`](#element-flood-project-ls)
+    - [`element flood use 'project-name'`](#element-flood-use-project-name)
+    - [`element flood project`](#element-flood-project)
+    - [`element flood run <path-to-script> [options]`](#element-flood-run-path-to-script-options)
 
 
 ## Installation
@@ -22,7 +31,7 @@ The easiest way to install on MacOS is via [homebrew](https://brew.sh):
 brew install flood-io/taps/element
 ```
 
-### via npm or yarn
+**via npm or yarn**
 
 If you're installing as an npm package, please first ensure you have the most recent version of node installed.
 
@@ -50,19 +59,19 @@ code test.ts
 element run test.ts
 ```
 
-## `element run`
+### `element run <file>`
 
-`element run test.ts` runs one iteration of your test script against a local browser.
+`element run test.ts` runs your test script against a local browser.
 
 Note that if your script loads CSV or JSON test data, the file is assumed to be in the same directory as the test script.
 
-### `--watch`
+**`--watch`**
 
 `--watch` runs your test script, then re-runs it when the script is changed (when you save it in your editor for example).
 
 `--watch` runs the test script against a single instance of the browser, so combining with `--no-headless` or `--devtools` shows the browser as the script runs, then leaves it open for you to inspect.
 
-### `--no-headless` / `--devtools`
+**`--no-headless` / `--devtools`**
 
 While developing your script, it can be handy to watch the script as it works through the actions you've defined.
 
@@ -72,7 +81,7 @@ While developing your script, it can be handy to watch the script as it works th
 
 Consider combining these flags with `--watch`. This will leave the test browser open for you to explore the state of the page e.g. via Chrome Devtools.
 
-### `--ff` / `--slow-mo`
+**`--ff` / `--slow-mo`**
 
 When running a script as a load test, you usually will set `actionDelay` and `stepDelay` to simulate users' think time, and perhaps to avoid overwhelming the target site.
 
@@ -86,42 +95,142 @@ You can use `--ff N` and `--slow-mo N` to set the delays to N seconds.
 
 You can also use `--step-delay TIME_IN_SECONDS` or `--action-delay TIME_IN_SECONDS`.
 
-### `--loop-count N`
+**`--loop-count N`**
 
 Set the number of iterations to run your test for. Since `element run` is usually used for developing and debugging test scripts, this is `1` by default.
 
 Setting a higher `--loop-count` could be useful for things like testing test data supply or generation.
 
-### `--chrome-version <custom-chrome-path>`
+**`--chrome <custom-chrome-path>`**
 
-Set the version of chrome to use. By default, `element run` uses the version of Chromium bundled with puppeteer.
+Set the version of chrome to use. By default, `element run` uses the version of Chromium bundled with Puppeteer.
 
-- `--chrome-version` with no arguments attempts to find and use the version of Chrome installed on your system.
-- `--chrome-version /path/to/chrome` will use Chrome at the given path.
+- `--chrome` with no arguments will be equivalent to `'puppeteer'` (i.e. use the version of Chromium bundled with Puppeteer). Change it to `'stable'` to use the Chrome version installed on your system.
+- `--chrome /path/to/chrome` will use Chrome at the given path.
 
-Note that when running as a load test [Tricentis Flood](https://flood.io), the versions of Chrome are recent but fixed to particular versions and may not match the custom version you select with this flag.
+Note that when running as a load test on [Tricentis Flood](https://flood.io), the versions of Chrome are recent but fixed to particular versions and may not match the custom version you select with this flag.
 Using the puppeteer-bundled version is a safe choice unless you need to test features which Chromium doesn't support such as DRM video playback.
 
-### `--no-sandbox`
+**`--no-sandbox`**
 
 Switch off the chrome sandbox. This is useful for some linux configurations which lack kernel support for the Chrome sandbox.
 
-### `--verbose`
+**`--verbose`**
+Print out the Test Settings and some load testing metrics like `throughput`, `response_time`, `latency`, `transaction_rate`, `passed`, `failed` while the test is running. 
 
-### (advanced) `--strict`
+**`--strict` (DEPRECATED)**
 
 Compile your script with stricter typescript type-checking. This can be useful for writing more robust test scripts and sometimes as a debugging tool for discovering subtle problems with your script.
 
 Specifically, this flag turns on the `strictNullChecks` and `noImplicitAny` TypeScript compiler flags. See the [TypeScript documentation](https://www.typescriptlang.org/docs/handbook/compiler-options.html) for more information.
 
-### (advanced) `--work-root`
-### (advanced) `--test-data-root`
+**`--work-root`**
+Specify a custom work root. (Default: a directory named after your test script, and at the same location)
 
-## `element plan`
-TODO
+**`--test-data-root`**
+Specify a custom path to find test data files. (Default: the same directory as the test script)
 
-## `element init`
-TODO
 
-## `element generate`
-TODO
+### `element plan <file> [options]`
+Output the test script plan without executing it.
+**Options**
+- `--json` (boolean) Output the test plan as JSON format. Defaults to `false`.
+
+### `element init [dir] [options]`
+Init a test script and a minimal environment to get you started with Flood Element.
+**Positionals**
+- `[dir]` (string) the directory to initialize with an Element test script. Defaults to the current directory.
+
+**Options**
+- `--skip-install` (boolean) Skip yarn/npm install. Defaults to `false`.
+
+
+### `element generate <file>`
+Generate a basic test script from a template.
+
+### `element generate config [file-name]`
+Generate a config file from a template.
+Flood Element supports using a config file across tests within a project. The default config file name (if not specified) is element.config.js, with the content as below.
+```js
+module.exports = {
+	options: {
+		headless: true,
+		devtools: false,
+		sandbox: true,
+		watch: false,
+		stepDelay: 0,
+		actionDelay: 0,
+		loopCount: 1,
+		strict: false,
+		failStatusCode: 1,
+		verbose: false,
+	},
+	paths: {
+		workRoot: '.',
+		testDataRoot: '.',
+		testPathMatch: ['./*.perf.ts'],
+	},
+	flood: {
+		hosted: false,
+		virtualUsers: 500,
+		duration: 15,
+		rampup: 0,
+		regions: [''],
+	},
+}
+```
+
+### `element run`
+Run a test locally with the default config file
+
+Element will find all the test scripts within the current project that match the `testPathMatch` pattern specified in the default config file, then sort the scripts alphabetically (by path-to-script) and execute those scripts sequentially, with the options as specified in the config file.
+
+### `element run --config-file [path-to-config-file]`
+Run a test locally with a custom config file
+
+This would be useful in case you want to reuse a config file across different projects. Provide an optional path to config file in case you want to use another custom config file other than the default `element.config.js` file in the current project.
+
+
+## Run an Element script on Flood
+
+Since Element 1.3.0, you can launch a flood directly from Element CLI. To do so, you need to be authenticated with Flood first.
+
+### `element flood authenticate <flood-api-token>`
+Authenticate with Flood from Element CLI
+
+Visit https://app.flood.io/account/api to get your API Token, then paste it into the above command to get authenticated. Unless you want to change the API Token, this step should be done only once.
+
+### `element flood project ls`
+List all Flood projects
+
+### `element flood use 'project-name'`
+Select a Flood project to use
+
+or
+
+```shell
+element flood use <project-id>
+```
+
+Every flood needs to belong to a project. Therefore, you need to select a project to use before you can launch a flood.
+
+### `element flood project`
+Print the current project being used
+
+This command would be useful in case you forgot the Flood project that is being used.
+
+### `element flood run <path-to-script> [options]`
+Launch a flood from CLI with a test script 
+
+**Options**
+
+- `--hosted`: indicates you're going to run a flood on hosted grid. Ignore this option if you want to run an on-demand test.
+- `--vu`: number of virtual users to simulate. Default to `500` if not specified
+- `--duration`: length of the test, measured in minutes. Default to `15` minutes if not specified.
+- `--rampup`: the amount of time it will take to reach the defined number of `vu`, measured in minutes. Default to `0` if not specified.
+
+> **_NOTE:_**
+> After running the command `element run flood`, you will be asked to select regions (to run on-demand test), or grids (to run a test on a hosted grid). To navigate among the options, use the Up/Down arrow key. To select an option, press the Space bar. You can select multiple options if you want.
+
+
+

--- a/packages/cli/src/cmd/run.ts
+++ b/packages/cli/src/cmd/run.ts
@@ -184,14 +184,7 @@ async function runTestScript(args: RunCommonArguments): Promise<void> {
 		opts.testCommander = makeTestCommander(file)
 	}
 
-	try {
-		await runCommandLine(opts)
-	} catch (err) {
-		console.log('Element exited with error')
-		console.error(err)
-		const exitCode = args['fail-status-code']
-		process.exit(exitCode)
-	}
+	await runCommandLine(opts)
 }
 
 async function runTestScriptWithConfiguration(args: RunCommonArguments): Promise<void> {
@@ -223,7 +216,13 @@ const cmd: CommandModule = {
 
 	async handler(args: RunCommonArguments): Promise<void> {
 		if (args.file) {
-			await runTestScript(args)
+			try {
+				await runTestScript(args)
+			} catch (err) {
+				console.log('Element exited with error')
+				console.error(err)
+				process.exit(args['fail-status-code'])
+			}
 		} else {
 			await runTestScriptWithConfiguration(args)
 		}

--- a/packages/cli/src/cmd/run.ts
+++ b/packages/cli/src/cmd/run.ts
@@ -172,7 +172,6 @@ async function runTestScript(args: RunCommonArguments): Promise<void> {
 		runEnv: initRunEnv(workRootPath, testDataPath),
 		testSettingOverrides: {},
 		persistentRunner: false,
-		failStatusCode: args['fail-status-code'],
 	}
 
 	if (args.loopCount) {
@@ -185,7 +184,14 @@ async function runTestScript(args: RunCommonArguments): Promise<void> {
 		opts.testCommander = makeTestCommander(file)
 	}
 
-	await runCommandLine(opts)
+	try {
+		await runCommandLine(opts)
+	} catch (err) {
+		console.log('Element exited with error')
+		console.error(err)
+		const exitCode = args['fail-status-code']
+		process.exit(exitCode)
+	}
 }
 
 async function runTestScriptWithConfiguration(args: RunCommonArguments): Promise<void> {
@@ -295,7 +301,8 @@ const cmd: CommandModule = {
 			})
 			.option('strict', {
 				group: 'Running the test script:',
-				describe: '[DEPRECATED] Compile the script in strict mode. This can be helpful in diagnosing problems.',
+				describe:
+					'[DEPRECATED] Compile the script in strict mode. This can be helpful in diagnosing problems.',
 			})
 			.option('work-root', {
 				group: 'Paths:',

--- a/packages/cli/src/cmd/run.ts
+++ b/packages/cli/src/cmd/run.ts
@@ -205,7 +205,10 @@ async function runTestScriptWithConfiguration(args: RunCommonArguments): Promise
 			...paths,
 			file,
 		}
-		await runTestScript(arg)
+		try {
+			await runTestScript(arg)
+			// eslint-disable-next-line no-empty
+		} catch {}
 	}
 	console.info('Test running with the config file has finished')
 }

--- a/packages/core/src/Element.ts
+++ b/packages/core/src/Element.ts
@@ -29,7 +29,6 @@ export interface ElementOptions {
 	testObserverFactory?: (t: TestObserver) => TestObserver
 	persistentRunner: boolean
 	testCommander?: TestCommander
-	failStatusCode: number
 }
 
 export async function runCommandLine(opts: ElementOptions): Promise<void> {
@@ -86,15 +85,9 @@ export async function runCommandLine(opts: ElementOptions): Promise<void> {
 		return new EvaluatedScript(opts.runEnv, await mustCompileFile(testScript, testScriptOptions))
 	}
 
-	try {
-		// eslint-disable-next-line @typescript-eslint/no-var-requires
-		const pkg = require(join(findRoot(__dirname), 'package.json'))
+	// eslint-disable-next-line @typescript-eslint/no-var-requires
+	const pkg = require(join(findRoot(__dirname), 'package.json'))
 
-		console.log(`Running the test with Element version ${pkg.version}`)
-		await runner.run(testScriptFactory)
-	} catch (err) {
-		console.log('Element exited with error')
-		console.error(err)
-		process.exit(opts.failStatusCode)
-	}
+	console.log(`Running the test with Element version ${pkg.version}`)
+	await runner.run(testScriptFactory)
 }

--- a/packages/core/src/Element.ts
+++ b/packages/core/src/Element.ts
@@ -88,6 +88,6 @@ export async function runCommandLine(opts: ElementOptions): Promise<void> {
 	// eslint-disable-next-line @typescript-eslint/no-var-requires
 	const pkg = require(join(findRoot(__dirname), 'package.json'))
 
-	console.log(`Running the test with Element version ${pkg.version}`)
+	console.log(`Running the test with:\n- Element v${pkg.version}\n- Node ${process.version}`)
 	await runner.run(testScriptFactory)
 }

--- a/packages/core/src/network/Interceptor.ts
+++ b/packages/core/src/network/Interceptor.ts
@@ -20,7 +20,7 @@ export default class Interceptor {
 	}
 
 	async detach(page: Page) {
-		page.off('request', this.requestBlocker)
+		page.removeListener('request', this.requestBlocker)
 		await page.setRequestInterception(false)
 	}
 

--- a/packages/docs/docs/api/ElementHandle.md
+++ b/packages/docs/docs/api/ElementHandle.md
@@ -214,6 +214,12 @@ Sends a series of key presses to the element to simulate a user typing on the ke
 - text `string`
 - returns: [`Promise<void>`][promise]
 
+### `uploadFile(filepath)`
+Sets the value of the file input. The name of a file you uploaded with this script. Relative to the script.
+
+**Parameters**
+- filepath `string` relative path to the file to be uploaded, separated by comma in case there're more than 1 file
+- returns: [`Promise<void>`][promise]
 
 [promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
 [clickoptions]: mouse.md#clickoptions

--- a/packages/docs/docs/api/TestData.md
+++ b/packages/docs/docs/api/TestData.md
@@ -145,7 +145,7 @@ Instructs the data feeder to repeat the data set when it reaches the end. TestDa
 
 Adds a filter to apply against each line in the data set.
 
-Filters can be chained, and will be run in order only if the previous ffilter passed.
+Filters can be chained, and will be run in order only if the previous filter passed.
 
 Example:
 

--- a/packages/docs/docs/guides/CLI.md
+++ b/packages/docs/docs/guides/CLI.md
@@ -24,11 +24,16 @@ element init [dir] [options]
 ```
 
 Init a test script, a default configuration file and a minimal environment to get you started with Flood Element.
+**Positionals**
+- `[dir]` (string) the directory to initialize with an Element test script. Defaults to the current directory.
+
+**Options**
+- `--skip-install` (boolean) Skip yarn/npm install. Defaults to `false`.
 
 ### Generate a basic test script from a template
 
 ```shell
-element generate <file> [options]
+element generate <file>
 ```
 
 ### Output the test script plan without executing it
@@ -36,6 +41,8 @@ element generate <file> [options]
 ```shell
 element plan <file> [options]
 ```
+**Options**
+- `--json` (boolean) Output the test plan as JSON format. Defaults to `false`.
 
 ### Run a test script locally
 
@@ -52,7 +59,7 @@ Positionals:
 - Browser:
 
   - `--chrome` Specify which version of Google Chrome to use. Default: use
-    the puppeteer bundled version.
+    the puppeteer bundled version. Change it to `'stable'` to use the Chrome version installed on your system, or provide a path to use Chrome at the given path.
   - `--no-headless` Run in non-headless mode so that you can see what the browser is doing as it runs the test.
   - `--devtools` Run in non-headless mode and also open devtools
   - `--no-sandbox` Disable the chrome sandbox - advanced option, mostly necessary on linux.

--- a/packages/docs/docs/guides/TestData.md
+++ b/packages/docs/docs/guides/TestData.md
@@ -158,6 +158,6 @@ Find more information in the API reference for [TestData], [TestDataFactory] and
 <!-- suffix -->
 
 [TypeScript]: https://www.typescriptlang.org/
-[TestData]: ../../api/TestData.md#testdata
-[TestDataFactory]: ../../api/TestData.md#testdatafactory
-[TestDataSource]: ../../api/TestData.md#testdatasource
+[TestData]: ../api/TestData.md#testdata
+[TestDataFactory]: ../api/TestData.md#testdatafactory
+[TestDataSource]: ../api/TestData.md#testdatasource

--- a/packages/docs/docs/start/changelog.md
+++ b/packages/docs/docs/start/changelog.md
@@ -2,8 +2,18 @@
 id: changelog
 title: Changelog
 ---
+## 1.3.6
+Released: 24 Sep 2020
+
+### Enhancements
+- Show Element version and Node version in terminal while running tests
+
+### Bugfixes
+- `ElementHandle.uploadFile()` has been implemented but is not exposed in the API
+- `Browser.wait()` returns value of type boolean only
+
 ## 1.3.3
-Released: Sep 2020
+Released: 18 Sep 2020
 
 ### Bugfixes
 - Backward compatible with legacy test scripts (actionDelay & stepDelay time measurement unit)

--- a/packages/docs/versioned_docs/version-1.0/guides/CLI.md
+++ b/packages/docs/versioned_docs/version-1.0/guides/CLI.md
@@ -17,26 +17,38 @@ element run help
 ## Working with Element locally
 
 ### Init a local Element project
+
 ```shell
 element init [dir] [options]
 ```
 
 Init a test script, a default configuration file and a minimal environment to get you started with Flood Element.
+**Positionals**
+- `[dir]` (string) the directory to initialize with an Element test script. Defaults to the current directory.
+
+**Options**
+- `--skip-install` (boolean) Skip yarn/npm install. Defaults to `false`.
 
 ### Generate a basic test script from a template
+
 ```shell
-element generate <file> [options]
+element generate <file>
 ```
 
 ### Output the test script plan without executing it
+
 ```shell
 element plan <file> [options]
 ```
+**Options**
+- `--json` (boolean) Output the test plan as JSON format. Defaults to `false`.
 
 ### Run a test script locally
+
 ```shell
 element run <file> [options]
 ```
+
 Positionals:
 
 **file:** the test script (or path to the test script) to run. Specifies a test script written in TypeScript with a `.ts` extension.
@@ -46,7 +58,7 @@ Positionals:
 - Browser:
 
   - `--chrome` Specify which version of Google Chrome to use. Default: use
-  the puppeteer bundled version.
+    the puppeteer bundled version. Change it to `'stable'` to use the Chrome version installed on your system, or provide a path to use Chrome at the given path.
   - `--no-headless` Run in non-headless mode so that you can see what the browser is doing as it runs the test.
   - `--devtools` Run in non-headless mode and also open devtools
   - `--no-sandbox` Disable the chrome sandbox - advanced option, mostly necessary on linux.

--- a/packages/docs/versioned_docs/version-1.3/api/ElementHandle.md
+++ b/packages/docs/versioned_docs/version-1.3/api/ElementHandle.md
@@ -214,6 +214,12 @@ Sends a series of key presses to the element to simulate a user typing on the ke
 - text `string`
 - returns: [`Promise<void>`][promise]
 
+### `uploadFile(filepath)`
+Sets the value of the file input. Names of the file(s) you uploaded with this script. Relative to the script.
+
+**Parameters**
+- filepath `string[]` relative path to the file to be uploaded, separated by comma in case there're more than 1 file
+- returns: [`Promise<void>`][promise]
 
 [promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
 [clickoptions]: mouse.md#clickoptions

--- a/packages/docs/versioned_docs/version-1.3/guides/CLI.md
+++ b/packages/docs/versioned_docs/version-1.3/guides/CLI.md
@@ -24,11 +24,16 @@ element init [dir] [options]
 ```
 
 Init a test script, a default configuration file and a minimal environment to get you started with Flood Element.
+**Positionals**
+- `[dir]` (string) the directory to initialize with an Element test script. Defaults to the current directory.
+
+**Options**
+- `--skip-install` (boolean) Skip yarn/npm install. Defaults to `false`.
 
 ### Generate a basic test script from a template
 
 ```shell
-element generate <file> [options]
+element generate <file>
 ```
 
 ### Output the test script plan without executing it
@@ -36,6 +41,8 @@ element generate <file> [options]
 ```shell
 element plan <file> [options]
 ```
+**Options**
+- `--json` (boolean) Output the test plan as JSON format. Defaults to `false`.
 
 ### Run a test script locally
 
@@ -52,7 +59,7 @@ Positionals:
 - Browser:
 
   - `--chrome` Specify which version of Google Chrome to use. Default: use
-    the puppeteer bundled version.
+    the puppeteer bundled version. Change it to `'stable'` to use the Chrome version installed on your system, or provide a path to use Chrome at the given path.
   - `--no-headless` Run in non-headless mode so that you can see what the browser is doing as it runs the test.
   - `--devtools` Run in non-headless mode and also open devtools
   - `--no-sandbox` Disable the chrome sandbox - advanced option, mostly necessary on linux.

--- a/packages/docs/versioned_docs/version-1.3/guides/TestData.md
+++ b/packages/docs/versioned_docs/version-1.3/guides/TestData.md
@@ -158,6 +158,6 @@ Find more information in the API reference for [TestData], [TestDataFactory] and
 <!-- suffix -->
 
 [TypeScript]: https://www.typescriptlang.org/
-[TestData]: ../../api/TestData.md#testdata
-[TestDataFactory]: ../../api/TestData.md#testdatafactory
-[TestDataSource]: ../../api/TestData.md#testdatasource
+[TestData]: ../api/TestData.md#testdata
+[TestDataFactory]: ../api/TestData.md#testdatafactory
+[TestDataSource]: ../api/TestData.md#testdatasource

--- a/packages/docs/versioned_docs/version-1.3/start/changelog.md
+++ b/packages/docs/versioned_docs/version-1.3/start/changelog.md
@@ -2,8 +2,18 @@
 id: changelog
 title: Changelog
 ---
+## 1.3.6
+Released: 24 Sep 2020
+
+### Enhancements
+- Show Element version and Node version in terminal while running tests
+
+### Bugfixes
+- `ElementHandle.uploadFile()` has been implemented but is not exposed in the API
+- `Browser.wait()` returns value of type boolean only
+
 ## 1.3.3
-Released: Sep 2020
+Released: 18 Sep 2020
 
 ### Bugfixes
 - Backward compatible with legacy test scripts (actionDelay & stepDelay time measurement unit)

--- a/packages/flood-runner/src/Grid.ts
+++ b/packages/flood-runner/src/Grid.ts
@@ -31,7 +31,6 @@ export async function run(file: string): Promise<void> {
 		testSettingOverrides: {},
 		testObserverFactory,
 		persistentRunner: false,
-		failStatusCode: 0,
 	}
 
 	if (gridConfig.testDuration !== undefined) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7366,28 +7366,10 @@ cssstyle@^2.0.0:
   dependencies:
     cssom "~0.3.6"
 
-csv-generate@^2.0.2:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/csv-generate/-/csv-generate-2.1.0.tgz#ba4bea4aa06858eae78fe16a403ef20e7cde6374"
-
-csv-parse@^2.4.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-2.5.0.tgz#65748997ecc3719c594622db1b9ea0e2eb7d56bb"
-
-csv-stringify@^3.0.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/csv-stringify/-/csv-stringify-3.1.1.tgz#3a4e180a84f9c45a6a0a0401c1b41b315b9131f0"
-  dependencies:
-    lodash.get "~4.4.2"
-
-csv@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/csv/-/csv-3.1.0.tgz#91ad8625e294bf37a5b366b84d01aa40b2d20f15"
-  dependencies:
-    csv-generate "^2.0.2"
-    csv-parse "^2.4.0"
-    csv-stringify "^3.0.0"
-    stream-transform "^1.0.2"
+csv-parse@^4.12.0:
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-4.12.0.tgz#fd42d6291bbaadd51d3009f6cadbb3e53b4ce026"
+  integrity sha512-wPQl3H79vWLPI8cgKFcQXl0NBgYYEqVnT1i6/So7OjMpsI540oD7p93r3w6fDSyPvwkTepG05F69/7AViX2lXg==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -12044,7 +12026,7 @@ lodash.foreach@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
   integrity sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=
 
-lodash.get@^4.4.2, lodash.get@~4.4.2:
+lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
 
@@ -17006,10 +16988,6 @@ stream-shift@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
-
-stream-transform@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/stream-transform/-/stream-transform-1.0.2.tgz#47de4d15fbc29b7e2a7e54d25e99538876f114c1"
 
 strftime@^0.10.0:
   version "0.10.0"


### PR DESCRIPTION
Fix: On Grids, tests stop running if there's a failed step, instead of skip to the next iteration