### PR TITLE
fix: change puppeteer API to unsubscribe from events

### DIFF
--- a/packages/core/src/Element.ts
+++ b/packages/core/src/Element.ts
@@ -90,7 +90,7 @@ export async function runCommandLine(opts: ElementOptions): Promise<void> {
 		// eslint-disable-next-line @typescript-eslint/no-var-requires
 		const pkg = require(join(findRoot(__dirname), 'package.json'))
 
-		console.log(`Running the test with Element version ${pkg.version}`)
+		console.log(`Running the test with:\n- Element v${pkg.version}\n- Node ${process.version}`)
 		await runner.run(testScriptFactory)
 	} catch (err) {
 		console.log('Element exited with error')

--- a/packages/core/src/network/Interceptor.ts
+++ b/packages/core/src/network/Interceptor.ts
@@ -20,7 +20,7 @@ export default class Interceptor {
 	}
 
 	async detach(page: Page) {
-		page.off('request', this.requestBlocker)
+		page.removeListener('request', this.requestBlocker)
 		await page.setRequestInterception(false)
 	}
 


### PR DESCRIPTION
- Change the API from `page.off()` to `page.removeListener()` to work compatible with Node v8.9+.
- Show the Element and Node version when running tests.