### PR TITLE
[Element 1.4] Edit publish config to specify the exact version of updated dependencies

### DIFF
--- a/.github/workflows/lerna-beta.yml
+++ b/.github/workflows/lerna-beta.yml
@@ -37,7 +37,7 @@ jobs:
       - name: 'Build all'
         run: yarn build
       - name: 'Publish beta to NPM'
-        run: yarn lerna publish --conventional-prerelease --dist-tag beta --yes --preid beta --include-merged-tags --force-publish
+        run: yarn lerna publish --conventional-prerelease --dist-tag beta --yes --preid beta --include-merged-tags --force-publish --exact
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: 'Publish beta to Homebrew'

--- a/.github/workflows/lerna-stable.yml
+++ b/.github/workflows/lerna-stable.yml
@@ -35,7 +35,7 @@ jobs:
       - name: 'Build all'
         run: yarn build
       - name: 'Publish stable to NPM'
-        run: yarn lerna publish --conventional-graduate --dist-tag latest --yes --force-publish
+        run: yarn lerna publish --conventional-graduate --dist-tag latest --yes --force-publish --exact
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: 'Publish stable to Homebrew'

--- a/lerna.json
+++ b/lerna.json
@@ -20,6 +20,9 @@
 		},
 		"bootstrap": {
 			"npmClient": "yarn"
+		},
+		"add": {
+			"exact": true
 		}
 	},
 	"ignoreChanges": [

--- a/lerna.json
+++ b/lerna.json
@@ -20,9 +20,6 @@
 		},
 		"bootstrap": {
 			"npmClient": "yarn"
-		},
-		"add": {
-			"exact": true
 		}
 	},
 	"ignoreChanges": [

--- a/packages/cli/src/generator/test-env/index.ts
+++ b/packages/cli/src/generator/test-env/index.ts
@@ -110,8 +110,8 @@ export default class TestEnv extends Generator {
 			},
 
 			dependencies: {
-				'@flood/element': `^${this.elementVersion}`,
-				'@flood/element-cli': `^${this.elementVersion}`,
+				'@flood/element': `${this.elementVersion}`,
+				'@flood/element-cli': `${this.elementVersion}`,
 				assert: `*`,
 				faker: `*`,
 				prettier: '*',


### PR DESCRIPTION
Add a flag `--exact` when publishing a new version of stable version and beta version to specify updated dependencies in updated packages **exactly** (with no punctuation), instead of as semver compatible **(with a ^)**.

More specifically, please take a look at [documentation of lerna](https://github.com/lerna/lerna/tree/master/commands/version#--exact).