### PR TITLE
[Element v1.4] Prevent Lerna auto-bumping version when modifying docs (*.md & packages/docs/**)

### DIFF
--- a/.github/workflows/lerna-beta.yml
+++ b/.github/workflows/lerna-beta.yml
@@ -37,7 +37,7 @@ jobs:
       - name: 'Build all'
         run: yarn build
       - name: 'Publish beta to NPM'
-        run: yarn lerna publish --conventional-prerelease --dist-tag beta --yes --preid beta --include-merged-tags --force-publish --exact
+        run: yarn lerna publish --conventional-prerelease --dist-tag beta --yes --preid beta --include-merged-tags --force-publish --exact --ignore-changes '**/*.md'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: 'Publish beta to Homebrew'

--- a/.github/workflows/lerna-beta.yml
+++ b/.github/workflows/lerna-beta.yml
@@ -37,7 +37,7 @@ jobs:
       - name: 'Build all'
         run: yarn build
       - name: 'Publish beta to NPM'
-        run: yarn lerna publish --conventional-prerelease --dist-tag beta --yes --preid beta --include-merged-tags --force-publish --exact --ignore-changes '**/*.md'
+        run: yarn lerna publish --conventional-prerelease --dist-tag beta --yes --preid beta --include-merged-tags --force-publish --exact --ignore-changes '**/*.md' 'packages/docs/**'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: 'Publish beta to Homebrew'

--- a/.github/workflows/lerna-stable.yml
+++ b/.github/workflows/lerna-stable.yml
@@ -35,7 +35,7 @@ jobs:
       - name: 'Build all'
         run: yarn build
       - name: 'Publish stable to NPM'
-        run: yarn lerna publish --conventional-graduate --dist-tag latest --yes --force-publish --exact --ignore-changes '**/*.md'
+        run: yarn lerna publish --conventional-graduate --dist-tag latest --yes --force-publish --exact --ignore-changes '**/*.md' 'packages/docs/**'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: 'Publish stable to Homebrew'

--- a/.github/workflows/lerna-stable.yml
+++ b/.github/workflows/lerna-stable.yml
@@ -35,7 +35,7 @@ jobs:
       - name: 'Build all'
         run: yarn build
       - name: 'Publish stable to NPM'
-        run: yarn lerna publish --conventional-graduate --dist-tag latest --yes --force-publish --exact
+        run: yarn lerna publish --conventional-graduate --dist-tag latest --yes --force-publish --exact --ignore-changes '**/*.md'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: 'Publish stable to Homebrew'

--- a/lerna.json
+++ b/lerna.json
@@ -23,5 +23,5 @@
 			"npmClient": "yarn"
 		}
 	},
-	"ignoreChanges": ["assets", "coverage", "examples", "scripts", "smoke", "**/*.md"]
+	"ignoreChanges": ["assets", "coverage", "examples", "scripts", "smoke", "**/*.md", "packages/docs/**"]
 }

--- a/lerna.json
+++ b/lerna.json
@@ -8,7 +8,8 @@
 			"exact": true
 		},
 		"publish": {
-			"conventionalCommits": true
+			"conventionalCommits": true,
+			"ignoreChanges": ["*.md"]
 		},
 		"version": {
 			"message": "chore(release): publish %s\n[skip ci]",
@@ -22,11 +23,5 @@
 			"npmClient": "yarn"
 		}
 	},
-	"ignoreChanges": [
-		"assets",
-		"coverage",
-		"examples",
-		"scripts",
-		"smoke"
-	]
+	"ignoreChanges": ["assets", "coverage", "examples", "scripts", "smoke", "**/*.md"]
 }

--- a/lerna.json
+++ b/lerna.json
@@ -8,8 +8,7 @@
 			"exact": true
 		},
 		"publish": {
-			"conventionalCommits": true,
-			"ignoreChanges": ["*.md"]
+			"conventionalCommits": true
 		},
 		"version": {
 			"message": "chore(release): publish %s\n[skip ci]",


### PR DESCRIPTION
Edit file `lerna.json`:

- Add option `ignoreChanges: ["*.md", "packages/docs/**"]` into `command.publish`.
- Add `**/*md` & `packages/docs/**` to `ignoreChanges`.

For more information, please take a look at [Lerna.json](https://github.com/lerna/lerna#lernajson) and [lerna version --ignore-change](https://github.com/lerna/lerna/tree/master/commands/version#--ignore-changes)