### PR TITLE
[Element 1.4] Introduce `browser.getUrl()` as new API

### DIFF
--- a/packages/core/src/runtime/Browser.spec.ts
+++ b/packages/core/src/runtime/Browser.spec.ts
@@ -349,4 +349,16 @@ describe('Browser', () => {
 			})
 		})
 	})
+
+	describe('getUrl', () => {
+		test('test API getUrl()', async () => {
+			const setting: any = normalizeSettings(DEFAULT_SETTINGS)
+			const browser = new Browser(workRoot, puppeteer, setting)
+			const URL = 'https://challenge.flood.io/'
+
+			await browser.visit(URL)
+			const currentURL = await browser.getUrl()
+			expect(currentURL).toBe(URL)
+		})
+	})
 })

--- a/packages/core/src/runtime/Browser.spec.ts
+++ b/packages/core/src/runtime/Browser.spec.ts
@@ -357,7 +357,7 @@ describe('Browser', () => {
 			const URL = 'https://challenge.flood.io/'
 
 			await browser.visit(URL)
-			const currentURL = await browser.getUrl()
+			const currentURL = browser.getUrl()
 			expect(currentURL).toBe(URL)
 		})
 	})

--- a/packages/core/src/runtime/Browser.ts
+++ b/packages/core/src/runtime/Browser.ts
@@ -739,8 +739,7 @@ export class Browser<T> implements BrowserInterface {
 		)
 	}
 
-	@addCallbacks()
-	public async getUrl(): Promise<string> {
+	public getUrl(): string {
 		return this.page.url()
 	}
 }

--- a/packages/core/src/runtime/Browser.ts
+++ b/packages/core/src/runtime/Browser.ts
@@ -738,4 +738,9 @@ export class Browser<T> implements BrowserInterface {
 			behavior,
 		)
 	}
+
+	@addCallbacks()
+	public async getUrl(): Promise<string> {
+		return this.page.url()
+	}
 }

--- a/packages/core/src/runtime/IBrowser.ts
+++ b/packages/core/src/runtime/IBrowser.ts
@@ -322,7 +322,7 @@ export interface Browser {
 	/**
 	 * Get the current URL of the page
 	 */
-	getUrl(): Promise<string>
+	getUrl(): string
 }
 
 /**

--- a/packages/core/src/runtime/IBrowser.ts
+++ b/packages/core/src/runtime/IBrowser.ts
@@ -318,6 +318,11 @@ export interface Browser {
 		y: number | 'window.innerHeight',
 		scrollOptions?: ScrollOptions,
 	): Promise<void>
+
+	/**
+	 * Get the current URL of the page
+	 */
+	getUrl(): Promise<string>
 }
 
 /**


### PR DESCRIPTION
**browser.getUrl()**

**Description**: Return the URL of the current page as a string.

**Params**: none

**Return**: current URL as a string