### PR TITLE
[Element 2.0] Apply features from version 1.4 to version 2.0

### DIFF
--- a/examples/scroll/scrollTo.perf.ts
+++ b/examples/scroll/scrollTo.perf.ts
@@ -1,0 +1,80 @@
+import { step, TestSettings, By } from '@flood/element'
+
+export const settings: TestSettings = {
+	loopCount: 1,
+	waitUntil: 'visible',
+	clearCache: false,
+	clearCookies: false,
+	disableCache: false,
+	waitTimeout: '60s',
+	screenshotOnFailure: true,
+	viewport: { width: 1600, height: 900 },
+	launchArgs: ['--window-size=1600,900'],
+	stepDelay: '1s',
+	actionDelay: '500ms',
+}
+
+const URL = 'https://testscroll.hongla.dev/'
+
+export default () => {
+	step('[01] -  Test Scroll with Target is Point and ScrollDirection', async browser => {
+		await browser.visit(URL, {waitUntil: 'load'})
+		await browser.wait(2)
+
+		console.info('[INFO]: ScrollTo with param is ScrollDirection bottom')
+		await browser.scrollTo('bottom', { behavior: 'smooth' })
+		await browser.wait(2)
+
+		console.info('[INFO]: ScrollTo with param is ScrollDirection top')
+		await browser.scrollTo('top', { behavior: 'smooth' })
+		await browser.wait(2)
+
+		console.info('[INFO]: ScrollTo with param is Point')
+		await browser.scrollTo([500, 1000], { behavior: 'smooth' })
+		await browser.wait(2)
+
+		console.info('[INFO]: ScrollTo with param is ScrollDirection right')
+		await browser.scrollTo('right', { behavior: 'smooth' })
+		await browser.wait(2)
+
+		console.info('[INFO]: ScrollTo with param is ScrollDirection left')
+		await browser.scrollTo('left', { behavior: 'smooth' })
+		await browser.wait(2)
+
+		console.info('[INFO]: ScrollTo with param is Locator')
+		const button = By.css('.btn')
+		await browser.scrollTo(button, { behavior: 'smooth', block: 'center', inline: 'center' })
+		await browser.wait(2)
+
+		console.info('[INFO]: ScrollTo with param is ElementHandle')
+		const paragraph = await browser.findElement('p')
+		await browser.scrollTo(paragraph, { behavior: 'smooth', block: 'nearest' })
+		await browser.wait(2)
+
+		console.info('[INFO]: ScrollBy without ScrollOptions')
+		await browser.scrollBy(700, 400)
+		await browser.wait(2)
+
+		console.info('[INFO]: ScrollBy with ScrollOptions')
+		await browser.scrollBy(0, -400, { behavior: 'smooth' })
+		await browser.wait(2)
+
+		await browser.scrollTo([0, 0])
+		await browser.wait(2)
+
+		// Using scrollBy with special value window.innerHeight or window.innerWidth
+		// We can get the innerHeight by browser.evaluate() then pass it as a param in browser.scrollBy()
+		const innerHeight: number = await browser.evaluate(() => window.innerHeight)
+		console.info('[INFO]: ScrollBy with window.innerHeight')
+		await browser.scrollBy(0, innerHeight, { behavior: 'smooth' })
+		await browser.wait(2)
+
+		// Or we can use the string 'window.innerWidth' and pass it as param in browser.scrollBy()
+		console.info('[INFO]: ScrollBy with innerWidth')
+		await browser.scrollBy('window.innerWidth', 0, { behavior: 'smooth' })
+		await browser.wait(2)
+
+		await browser.scrollBy(0, -innerHeight, { behavior: 'smooth' })
+		await browser.wait(10)
+	})
+}

--- a/extern/dogfood/dockerfiles/watirspec/html/scroll.html
+++ b/extern/dogfood/dockerfiles/watirspec/html/scroll.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Test API ScrollTo and ScrollBy</title>
+		<style>
+			header,
+			footer {
+				width: 2884px;
+				height: 1450px;
+			}
+
+			header {
+				background-color: #7f9cf5;
+			}
+
+			footer {
+				background-color: #97266d;
+			}
+
+			.container {
+				background-color: #faf5ff;
+				width: 100%;
+				height: 1000px;
+			}
+
+			#unique-btn {
+				width: 100px;
+				height: 50px;
+				margin: 500px 400px;
+			}
+		</style>
+	</head>
+	<body>
+		<header>
+			<span>This is the header</span>
+		</header>
+		<div class="container">
+			<p>This is the body of the page</p>
+			<button id="unique-btn" class="btn">I'm a button</button>
+		</div>
+		<footer>
+			<span>This is the footer</span>
+		</footer>
+	</body>
+</html>

--- a/packages/cli/templates/test.ts
+++ b/packages/cli/templates/test.ts
@@ -10,16 +10,16 @@ export const settings: TestSettings = {
 
 export default () => {
 	beforeAll(async browser => {
-		// Run this hook before all steps in file
+		// Run this hook before running the first step
 		await browser.wait('500ms')
 	})
 
 	afterAll(async browser => {
-		// Run this hook after all steps in file
+		// Run this hook after running the last step
 		await browser.wait('500ms')
 	})
 
-	// if you want to do some actions before/after every step, use beforeEach/afterEach
+	// If you want to do some actions before/after every single step, use beforeEach/afterEach
 	// beforeEach(async browser => {})
 	// afterEach(async browser => {})
 

--- a/packages/core/src/Element.ts
+++ b/packages/core/src/Element.ts
@@ -9,6 +9,8 @@ import chalk from 'chalk'
 import { EventEmitter } from 'events'
 import { ElementResult } from './ElementResult'
 import { existsSync } from 'fs'
+import { join } from 'path'
+import findRoot from 'find-root'
 
 export async function runSingleTestScript(opts: ElementOptions): Promise<IterationResult[]> {
 	const {
@@ -93,7 +95,11 @@ export async function runCommandLine(args: ElementRunArguments): Promise<TestRes
 		elementResult: ElementResult,
 		isConfig: boolean,
 	) => {
-		console.group(chalk('Running', fileTitle))
+		// eslint-disable-next-line @typescript-eslint/no-var-requires
+		const pkg = require(join(findRoot(__dirname), 'package.json'))
+		console.group(
+			chalk(`Running ${fileTitle} with\n- Element v${pkg.version}\n- Node ${process.version}`),
+		)
 		const opts = normalizeElementOptions(args, cache)
 		elementResult.addExecutionInfo(opts, isConfig)
 

--- a/packages/core/src/interface/IBrowser.ts
+++ b/packages/core/src/interface/IBrowser.ts
@@ -296,6 +296,8 @@ export interface Browser {
 	context(): BrowserContext
 
 	getCookies(filterBy?: CookiesFilterParams): Promise<Cookie[]>
+
+	getUrl(): string
 }
 
 /**

--- a/packages/core/src/interface/IBrowser.ts
+++ b/packages/core/src/interface/IBrowser.ts
@@ -295,9 +295,30 @@ export interface Browser {
 
 	context(): BrowserContext
 
+	/**
+	 *
+	 * @param filterBy urls or cookie's name (names). Urls and names can be a string or an array of string
+	 */
 	getCookies(filterBy?: CookiesFilterParams): Promise<Cookie[]>
 
+	/**
+	 * Get the current URL of the page
+	 */
 	getUrl(): string
+
+	/**
+	 *
+	 * @param x How many pixels to scroll by, along the x-axis (horizontal). Positive values will scroll to the right, while negative values will scroll to the left.
+	 * Param x can take 'window.innerWidth' as a special value
+	 * @param y How many pixels to scroll by, along the y-axis (vertical). Positive values will scroll down, while negative values scroll up.
+	 * Param y can take 'window.innerHeight' as a special value
+	 * @param scrollOptions behavior of scroll (auto or smooth)
+	 */
+	scrollBy(
+		x: number | 'window.innerWidth',
+		y: number | 'window.innerHeight',
+		scrollOptions?: ScrollOptions,
+	): Promise<void>
 }
 
 /**

--- a/packages/core/src/interface/IBrowser.ts
+++ b/packages/core/src/interface/IBrowser.ts
@@ -7,12 +7,15 @@ import {
 	EvaluateFn,
 	ClickOptions,
 	CookiesFilterParams,
+	Locator,
+	ScrollDirection,
 } from '../page/types'
 import { NullableLocatable } from '../runtime/Locatable'
 import { TargetLocator } from '../page/TargetLocator'
 import Mouse from '../page/Mouse'
 import { TestSettings } from '../runtime/Settings'
 import { DeviceDescriptor } from '../page/Device'
+import { Point } from '../page/Point'
 
 /**
  * Browser is the main entry point in each <[step]>, it's your direct connection to the browser running the test.
@@ -318,6 +321,16 @@ export interface Browser {
 		x: number | 'window.innerWidth',
 		y: number | 'window.innerHeight',
 		scrollOptions?: ScrollOptions,
+	): Promise<void>
+
+	/**
+	 *
+	 * @param target target to scroll
+	 * @param behavior behavior of scroll (auto or smooth)
+	 */
+	scrollTo(
+		target: Locator | ElementHandle | Point | ScrollDirection,
+		scrollOptions?: ScrollIntoViewOptions,
 	): Promise<void>
 }
 

--- a/packages/core/src/page/types.ts
+++ b/packages/core/src/page/types.ts
@@ -283,3 +283,6 @@ export interface CookiesFilterParams {
 	urls?: string | string[]
 	names?: string | string[]
 }
+
+// Using the type below for API scrollTo()
+export type ScrollDirection = 'top' | 'left' | 'bottom' | 'right'

--- a/packages/core/src/runtime/Browser.spec.ts
+++ b/packages/core/src/runtime/Browser.spec.ts
@@ -233,4 +233,13 @@ describe('Browser', () => {
 		expect(getCookiesByStringArray[0].name).toStrictEqual('element-cookie')
 		expect(getCookiesByStringArray[1].name).toStrictEqual('floodio')
 	})
+
+	test('action getUrl()', async () => {
+		const browser = new Browser(workRoot, playwright, DEFAULT_SETTINGS)
+		const URL = 'https://challenge.flood.io/'
+		await browser.visit(URL, { waitUntil: 'load' })
+
+		const currentUrl = browser.getUrl()
+		expect(currentUrl).toStrictEqual(URL)
+	})
 })

--- a/packages/core/src/runtime/Browser.spec.ts
+++ b/packages/core/src/runtime/Browser.spec.ts
@@ -10,6 +10,15 @@ import { DEFAULT_SETTINGS } from './Settings'
 let playwright: testPlaywright
 const workRoot = testWorkRoot()
 
+const getCurrentPosition = async (
+	browser: Browser<any>,
+): Promise<{ top: number; left: number }> => {
+	return await browser.evaluate(() => ({
+		top: document.documentElement.scrollTop || document.body.scrollTop,
+		left: document.documentElement.scrollLeft || document.body.scrollLeft,
+	}))
+}
+
 describe('Browser', () => {
 	jest.setTimeout(30e3)
 	beforeAll(async () => {
@@ -241,5 +250,116 @@ describe('Browser', () => {
 
 		const currentUrl = browser.getUrl()
 		expect(currentUrl).toStrictEqual(URL)
+	})
+
+	describe('scrollTo and scrollBy', () => {
+		let browser: Browser<any>
+		let docScrollHeight: number,
+			docScrollWidth: number,
+			docClientHeight: number,
+			docClientWidth: number
+		beforeEach(async () => {
+			browser = new Browser(workRoot, playwright, DEFAULT_SETTINGS)
+			const url = await serve('scroll.html')
+
+			await browser.visit(url)
+			docScrollHeight = await browser.evaluate(() =>
+				Math.max(
+					document.body.scrollHeight,
+					document.documentElement.scrollHeight,
+					document.body.offsetHeight,
+					document.documentElement.offsetHeight,
+					document.body.clientHeight,
+					document.documentElement.clientHeight,
+				),
+			)
+
+			docScrollWidth = await browser.evaluate(() =>
+				Math.max(
+					document.body.scrollWidth,
+					document.documentElement.scrollWidth,
+					document.body.offsetWidth,
+					document.documentElement.offsetWidth,
+					document.body.clientWidth,
+					document.documentElement.clientWidth,
+				),
+			)
+
+			docClientHeight = await browser.evaluate(() => document.documentElement.clientHeight)
+			docClientWidth = await browser.evaluate(() => document.documentElement.clientWidth)
+		})
+
+		afterEach(async () => {
+			await browser.scrollTo('top')
+		})
+		test('scrollTo', async () => {
+			await browser.scrollTo('bottom', { behavior: 'smooth' })
+			await browser.wait(2)
+			const currentPosAfterScrollBot = await getCurrentPosition(browser)
+			expect(docScrollHeight - docClientHeight).toBe(currentPosAfterScrollBot.top)
+
+			await browser.scrollTo('right')
+			const currentPosAfterScrollRight = await getCurrentPosition(browser)
+			expect(docScrollWidth - docClientWidth).toBe(currentPosAfterScrollRight.left)
+
+			await browser.scrollTo('left')
+			const currentPosAfterScrollLeft = await getCurrentPosition(browser)
+			expect(currentPosAfterScrollLeft.left).toBe(0)
+
+			await browser.scrollTo('top')
+			const currentPosAfterScrollTop = await getCurrentPosition(browser)
+			expect(currentPosAfterScrollTop.top).toBe(0)
+
+			await browser.scrollTo([1000, 500])
+			const currentPosAfterScrollToPoint = await getCurrentPosition(browser)
+			expect(currentPosAfterScrollToPoint).toStrictEqual({ top: 500, left: 1000 })
+
+			const btn = By.css('.btn')
+			await browser.scrollTo(btn, { block: 'center', inline: 'start' })
+			const btnEl = await browser.findElement(btn)
+			const btnLocation = await btnEl.location()
+			const btnHeight = (await btnEl.element.boundingBox()).height
+			expect(Math.round((docClientHeight - btnHeight) / 2)).toBe(btnLocation.y)
+			expect(btnLocation.x).toBe(0)
+
+			const paragraph = await browser.findElement(By.css('p'))
+			await browser.scrollTo(paragraph, { block: 'start' })
+			const paragraphLocation = await paragraph.location()
+			expect(paragraphLocation.y).toBe(0)
+		})
+
+		test('scrollBy', async () => {
+			const beforeScrollBy = await getCurrentPosition(browser)
+			await browser.scrollBy(700, 400)
+			const currentPosAfterScrollBy = await getCurrentPosition(browser)
+			expect(currentPosAfterScrollBy).toStrictEqual({
+				top: beforeScrollBy.top + 400,
+				left: beforeScrollBy.left + 700,
+			})
+
+			await browser.scrollBy(-700, -400)
+			const currentPosAfterScrollByAgain = await getCurrentPosition(browser)
+			expect(currentPosAfterScrollByAgain).toStrictEqual({
+				top: currentPosAfterScrollBy.top - 400,
+				left: currentPosAfterScrollBy.left - 700,
+			})
+
+			await browser.scrollTo('top')
+			const currentPosAfterScrollTop = await getCurrentPosition(browser)
+
+			await browser.scrollBy(0, 'window.innerHeight')
+			const currentPosAfterScrollInnerHeight = await getCurrentPosition(browser)
+			expect(currentPosAfterScrollInnerHeight).toStrictEqual({
+				top: currentPosAfterScrollTop.top + docClientHeight,
+				left: currentPosAfterScrollTop.left,
+			})
+
+			await browser.scrollBy('window.innerWidth', 0)
+			const currentPosAfterScrollInnerWidth = await getCurrentPosition(browser)
+			expect(currentPosAfterScrollInnerWidth).toStrictEqual({
+				top: currentPosAfterScrollInnerHeight.top,
+				left: currentPosAfterScrollInnerHeight.left + docClientWidth,
+			})
+		})
 	})
 })

--- a/packages/core/src/runtime/Browser.ts
+++ b/packages/core/src/runtime/Browser.ts
@@ -590,6 +590,45 @@ export class Browser<T> implements BrowserInterface {
 		return this.page.url()
 	}
 
+	private isCorrectScrollBehavior(behavior: string): behavior is ScrollBehavior {
+		return ['auto', 'smooth'].includes(behavior)
+	}
+
+	public async scrollBy(
+		x: number | 'window.innerWidth',
+		y: number | 'window.innerHeight',
+		scrollOptions?: ScrollOptions,
+	): Promise<void> {
+		const behavior = scrollOptions?.behavior ?? 'auto'
+
+		if (!this.isCorrectScrollBehavior(behavior)) {
+			throw new Error('The input behavior is not correct (Must be "auto" or "smooth").')
+		}
+
+		if (x !== 'window.innerWidth' && typeof x !== 'number') {
+			throw new Error(
+				'The input x that you want to scroll by must be "window.innerWidth" or a number.',
+			)
+		}
+
+		if (y !== 'window.innerHeight' && typeof y !== 'number') {
+			throw new Error(
+				'The input y that you want to scroll by must be "window.innerHeight" or a number.',
+			)
+		}
+
+		await this.page.evaluate(
+			({ x, y, behavior }) => {
+				window.scrollBy({
+					top: y === 'window.innerHeight' ? window.innerHeight : y,
+					left: x === 'window.innerWidth' ? window.innerWidth : x,
+					behavior,
+				})
+			},
+			{ x, y, behavior },
+		)
+	}
+
 	private async evaluateWithoutDecorator(fn: EvaluateFn, ...args: any[]): Promise<any> {
 		return this.target.evaluate(fn, ...args)
 	}

--- a/packages/core/src/runtime/Browser.ts
+++ b/packages/core/src/runtime/Browser.ts
@@ -586,6 +586,10 @@ export class Browser<T> implements BrowserInterface {
 		return cookies
 	}
 
+	public getUrl(): string {
+		return this.page.url()
+	}
+
 	private async evaluateWithoutDecorator(fn: EvaluateFn, ...args: any[]): Promise<any> {
 		return this.target.evaluate(fn, ...args)
 	}

--- a/packages/core/src/runtime/Browser.ts
+++ b/packages/core/src/runtime/Browser.ts
@@ -661,16 +661,16 @@ export class Browser<T> implements BrowserInterface {
 			!isPoint(target) &&
 			typeof target !== 'string'
 		) {
-			console.log('hello')
 			const targetEl: ElementHandle = isLocator(target)
 				? await this.findElementWithoutDecorator(target)
 				: target
-			await targetEl.element.evaluate((elementNode, scrollOptions) => {
-				const span = document.createElement('span')
-				elementNode.appendChild(span)
-				const element = span.parentElement
-				element?.scrollIntoView(scrollOptions)
-			}, {behavior, block, inline})
+			await targetEl.element.evaluate(
+				(elementNode, scrollOptions) => {
+					const element = elementNode as HTMLElement
+					element.scrollIntoView(scrollOptions)
+				},
+				{ behavior, block, inline },
+			)
 			return
 		}
 

--- a/packages/core/src/utils/CheckInstance.ts
+++ b/packages/core/src/utils/CheckInstance.ts
@@ -28,12 +28,12 @@ export const isFrameCondition = (arg: unknown): boolean => isInstanceOf(arg, [Fr
 export const isElementTextCondition = (arg: unknown): boolean =>
 	isInstanceOf(arg, [ElementTextCondition, ElementTextNotMatchCondition])
 
+// Using for API scrollBy() and scrollTo()
 export const isLocator = (
 	target: Locator | ElementHandle | Point | ScrollDirection,
-): target is Locator => {
-	return target instanceof BaseLocator
-}
+): target is Locator => isInstanceOf(target, [BaseLocator])
 
+// Using for API scrollBy() and scrollTo()
 export const isPoint = (
 	target: Locator | ElementHandle | Point | ScrollDirection,
 ): target is Point => {

--- a/packages/core/src/utils/CheckInstance.ts
+++ b/packages/core/src/utils/CheckInstance.ts
@@ -1,0 +1,46 @@
+import {
+	ElementTextCondition,
+	ElementTextNotMatchCondition,
+	FrameCondition,
+	TitleCondition,
+	TitleNotMatchCondition,
+	URLCondition,
+	URLNotMatchCondition,
+} from '../page/conditions'
+import { ElementHandle as TargetElementHandle } from '../page/ElementHandle'
+import { BaseLocator } from '../page/Locator'
+import { Point } from '../page/Point'
+import { Locator, ScrollDirection, ElementHandle } from '../page/types'
+
+export const isInstanceOf = (arg: any, conditions: Array<any>) =>
+	conditions.some(condition => arg instanceof condition)
+
+export const isAnElementHandle = (arg: any): boolean => isInstanceOf(arg, [TargetElementHandle])
+
+export const isURLCondition = (arg: any): boolean =>
+	isInstanceOf(arg, [URLCondition, URLNotMatchCondition])
+
+export const isTitleCondition = (arg: any): boolean =>
+	isInstanceOf(arg, [TitleCondition, TitleNotMatchCondition])
+
+export const isFrameCondition = (arg: any): boolean => isInstanceOf(arg, [FrameCondition])
+
+export const isElementTextCondition = (arg: any): boolean =>
+	isInstanceOf(arg, [ElementTextCondition, ElementTextNotMatchCondition])
+
+export const isLocator = (
+	target: Locator | ElementHandle | Point | ScrollDirection,
+): target is Locator => {
+	return target instanceof BaseLocator
+}
+
+export const isPoint = (
+	target: Locator | ElementHandle | Point | ScrollDirection,
+): target is Point => {
+	return (
+		Array.isArray(target) &&
+		target.length === 2 &&
+		typeof target[0] === 'number' &&
+		typeof target[1] === 'number'
+	)
+}

--- a/packages/core/src/utils/CheckInstance.ts
+++ b/packages/core/src/utils/CheckInstance.ts
@@ -12,20 +12,20 @@ import { BaseLocator } from '../page/Locator'
 import { Point } from '../page/Point'
 import { Locator, ScrollDirection, ElementHandle } from '../page/types'
 
-export const isInstanceOf = (arg: any, conditions: Array<any>) =>
+export const isInstanceOf = (arg: unknown, conditions: Array<any>): boolean =>
 	conditions.some(condition => arg instanceof condition)
 
-export const isAnElementHandle = (arg: any): boolean => isInstanceOf(arg, [TargetElementHandle])
+export const isAnElementHandle = (arg: unknown): boolean => isInstanceOf(arg, [TargetElementHandle])
 
-export const isURLCondition = (arg: any): boolean =>
+export const isURLCondition = (arg: unknown): boolean =>
 	isInstanceOf(arg, [URLCondition, URLNotMatchCondition])
 
-export const isTitleCondition = (arg: any): boolean =>
+export const isTitleCondition = (arg: unknown): boolean =>
 	isInstanceOf(arg, [TitleCondition, TitleNotMatchCondition])
 
-export const isFrameCondition = (arg: any): boolean => isInstanceOf(arg, [FrameCondition])
+export const isFrameCondition = (arg: unknown): boolean => isInstanceOf(arg, [FrameCondition])
 
-export const isElementTextCondition = (arg: any): boolean =>
+export const isElementTextCondition = (arg: unknown): boolean =>
 	isInstanceOf(arg, [ElementTextCondition, ElementTextNotMatchCondition])
 
 export const isLocator = (

--- a/packages/core/src/utils/StepActionArgs.ts
+++ b/packages/core/src/utils/StepActionArgs.ts
@@ -15,6 +15,14 @@ import {
 	ElementsLocatedCondition,
 } from '../page/conditions/'
 import { ElementHandle } from './../page/ElementHandle'
+import {
+	isInstanceOf,
+	isAnElementHandle,
+	isURLCondition,
+	isTitleCondition,
+	isFrameCondition,
+	isElementTextCondition,
+} from './CheckInstance'
 
 const conditions = [
 	DialogCondition,
@@ -32,22 +40,6 @@ const conditions = [
 	ElementsLocatedCondition,
 	ElementHandle,
 ]
-
-const isInstanceOf = (arg: any, conditions: Array<any>) =>
-	conditions.some(condition => arg instanceof condition)
-
-const isAnElementHandle = (arg: any): boolean => isInstanceOf(arg, [ElementHandle])
-
-const isURLCondition = (arg: any): boolean =>
-	isInstanceOf(arg, [URLCondition, URLNotMatchCondition])
-
-const isTitleCondition = (arg: any): boolean =>
-	isInstanceOf(arg, [TitleCondition, TitleNotMatchCondition])
-
-const isFrameCondition = (arg: any): boolean => isInstanceOf(arg, [FrameCondition])
-
-const isElementTextCondition = (arg: any): boolean =>
-	isInstanceOf(arg, [ElementTextCondition, ElementTextNotMatchCondition])
 
 const getErrorString = (locator: ElementHandle | BaseLocator): string => {
 	if (locator instanceof ElementHandle) {


### PR DESCRIPTION
Apply features from version 1.4 to version 2.0. Relate to this issue: [FLO-1962](https://tricentisflood.atlassian.net/browse/FLO-1962)

```
- Print version of Element and Node when running test.
- Apply API browser.getUrl()
- Apply API browser.scrollTo(target: Locator | ElementHandle | Point | ScrollDirection, scrollOptions?: ScrollIntoViewOptions)
- Apply API browser.scrollBy(x: number | 'window.innerWidth', y: number | 'window.innerHeight',  scrollOptions?: ScrollOptions)
```