### PR TITLE
[Bugfix][Element 1.4] Change default NavigationOptions waitUntil of browser.visit

### DIFF
--- a/packages/core/src/runtime/Browser.ts
+++ b/packages/core/src/runtime/Browser.ts
@@ -204,7 +204,7 @@ export class Browser<T> implements BrowserInterface {
 		try {
 			return this.page.goto(url, {
 				timeout: Number(this.settings.waitTimeout),
-				waitUntil: ['load', 'domcontentloaded', 'networkidle0', 'networkidle2'],
+				waitUntil: 'load',
 				...options,
 			})
 		} catch (e) {


### PR DESCRIPTION
Change the default NavigationOptions's waitUntil from `['load', 'domcontentloaded', 'networkidle0', 'networkidle2']` to `'load'`