### PR TITLE
[Element Canary] Set default viewport of client's browser

### DIFF
--- a/packages/core/src/runtime/Settings.ts
+++ b/packages/core/src/runtime/Settings.ts
@@ -282,7 +282,7 @@ export const DEFAULT_SETTINGS: ConcreteTestSettings = {
 	disableCache: false,
 	extraHTTPHeaders: {},
 	launchArgs: [],
-	viewport: null,
+	viewport: { width: 1440, height: 900 },
 	stages: [],
 }
 

--- a/packages/core/src/runtime/Test.spec.ts
+++ b/packages/core/src/runtime/Test.spec.ts
@@ -68,7 +68,7 @@ describe('Test', () => {
 			disableCache: false,
 			extraHTTPHeaders: {},
 			launchArgs: [],
-			viewport: null,
+			viewport: { width: 1440, height: 900 },
 			tries: 0,
 			stages: [],
 		}


### PR DESCRIPTION
Set the default viewport of the browser is `1440 x 900` instead of `800 x 600`