### PR TITLE
docs: update link for Flood Element Challenge [skip-ci]

### DIFF
--- a/examples/flood-element-challenge.ts
+++ b/examples/flood-element-challenge.ts
@@ -26,7 +26,7 @@ export const settings: TestSettings = {
 	actionDelay: '500ms',
 }
 
-const URL = 'https://flood-element-challenge.vercel.app/'
+const URL = 'https://element-challenge.flood.io/'
 
 const getNumOfPages = async (browser: Browser): Promise<number> => {
 	return await browser.evaluate(() => {

--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -119,7 +119,7 @@ module.exports = {
 						},
 						{
 							label: 'Flood Challenge',
-							href: 'https://flood-element-challenge.vercel.app/',
+							href: 'https://element-challenge.flood.io/',
 						},
 					],
 				},


### PR DESCRIPTION
Changed from: flood-element-challenge.vercel.app
To: https://element-challenge.flood.io/