### PR TITLE
[Element 2.0] Enhance text color of terminal output

### DIFF
--- a/packages/core/src/page/ElementHandle.ts
+++ b/packages/core/src/page/ElementHandle.ts
@@ -294,7 +294,6 @@ export class ElementHandle implements IElementHandle, Locator {
 	public async takeScreenshot(options?: ScreenshotOptions): Promise<void> {
 		return this.fs.saveScreenshot(async path => {
 			debug(`Saving screenshot to: ${path}`)
-			console.log(`Saving screenshot to: ${path}`)
 
 			const handle = this.element.asElement()
 			if (!handle) return false

--- a/packages/report/src/reporters/Base.ts
+++ b/packages/report/src/reporters/Base.ts
@@ -34,9 +34,9 @@ export class BaseReporter implements IReporter {
 		errorMessage?: string,
 	): void {
 		const stepName = 'Step ' + (subtitle ? `'${label}' (${subtitle})` : `'${label}'`)
-		const beforeRunStepMessage = `${stepName} is running ...`
-		const beforeRunHookMessage = chalk.white(`${label} is running ...`)
-		const afterRunHookMessage = `${chalk.green.bold('✔')} ${chalk.grey(`${label} finished`)}`
+		const beforeRunStepMessage = chalk.whiteBright(`${stepName} is running ...`)
+		const beforeRunHookMessage = chalk.whiteBright(`${label} is running ...`)
+		const afterRunHookMessage = `${chalk.green.bold('✔')} ${chalk.whiteBright(`${label} finished`)}`
 		let message = ''
 		switch (stage) {
 			case TestEvent.BeforeAllStep:
@@ -54,7 +54,7 @@ export class BaseReporter implements IReporter {
 				console.groupEnd()
 				break
 			case TestEvent.BeforeStep:
-				console.group(chalk.white(beforeRunStepMessage))
+				console.group(beforeRunStepMessage)
 				console.group()
 				break
 			case TestEvent.StepSucceeded:
@@ -69,6 +69,12 @@ export class BaseReporter implements IReporter {
 				)}`
 				console.error(chalk.red(errorMessage?.length ? errorMessage : 'step error -> failed'))
 				this.updateMessage(beforeRunStepMessage, message)
+				console.log('')
+				break
+			case TestEvent.StepSkipped:
+				console.group(`${chalk.yellow.bold('\u2296')} ${chalk.yellow(`${stepName} skipped`)}`)
+				console.log('')
+				console.groupEnd()
 				break
 			case TestEvent.AfterStep:
 				console.groupEnd()

--- a/packages/report/src/reporters/Base.ts
+++ b/packages/report/src/reporters/Base.ts
@@ -35,7 +35,7 @@ export class BaseReporter implements IReporter {
 	): void {
 		const stepName = 'Step ' + (subtitle ? `'${label}' (${subtitle})` : `'${label}'`)
 		const beforeRunStepMessage = `${stepName} is running ...`
-		const beforeRunHookMessage = chalk.grey(`${label} is running ...`)
+		const beforeRunHookMessage = chalk.white(`${label} is running ...`)
 		const afterRunHookMessage = `${chalk.green.bold('✔')} ${chalk.grey(`${label} finished`)}`
 		let message = ''
 		switch (stage) {
@@ -54,17 +54,17 @@ export class BaseReporter implements IReporter {
 				console.groupEnd()
 				break
 			case TestEvent.BeforeStep:
-				console.group(chalk.grey(beforeRunStepMessage))
+				console.group(chalk.white(beforeRunStepMessage))
 				console.group()
 				break
 			case TestEvent.StepSucceeded:
-				message = `${chalk.green.bold('✔')} ${chalk.grey(
+				message = `${chalk.green.bold('✔')} ${chalk.green(
 					`${stepName} passed (${timing?.toLocaleString()}ms)`,
 				)}`
 				this.updateMessage(beforeRunStepMessage, message)
 				break
 			case TestEvent.StepFailed:
-				message = `${chalk.redBright.bold('✘')} ${chalk.grey(
+				message = `${chalk.redBright.bold('✘')} ${chalk.red(
 					`${stepName} failed (${timing?.toLocaleString()}ms)`,
 				)}`
 				console.error(chalk.red(errorMessage?.length ? errorMessage : 'step error -> failed'))

--- a/packages/report/src/reporters/Verbose.ts
+++ b/packages/report/src/reporters/Verbose.ts
@@ -58,7 +58,7 @@ export class VerboseReporter implements IReporter {
 				break
 			case TestEvent.AfterHookAction:
 			case TestEvent.AfterStepAction:
-				console.log(`${chalk.white(`${label}(${chalk.white.dim(args)})`)}`)
+				console.log(`${chalk.white(`${label}(${chalk.grey(args)})`)}`)
 				break
 			case TestEvent.StepSucceeded:
 				message = `${chalk.green.bold('✔')} ${chalk.green(
@@ -76,6 +76,7 @@ export class VerboseReporter implements IReporter {
 				break
 			case TestEvent.StepSkipped:
 				console.group(`${chalk.yellow.bold('\u2296')} ${chalk.yellow(`${stepName} skipped`)}`)
+				console.log('')
 				console.groupEnd()
 				break
 			case TestEvent.StepUnexecuted:

--- a/packages/report/src/reporters/Verbose.ts
+++ b/packages/report/src/reporters/Verbose.ts
@@ -33,9 +33,9 @@ export class VerboseReporter implements IReporter {
 		args?: string,
 	): void {
 		const stepName = 'Step ' + (subtitle ? `'${label}' (${subtitle})` : `'${label}'`)
-		const beforeRunStepMessage = `${stepName} is running ...`
-		const beforeRunHookMessage = chalk.white(`${label} is running ...`)
-		const afterRunHookMessage = `${chalk.green.bold('✔')} ${chalk.grey(`${label} finished`)}`
+		const beforeRunStepMessage = chalk.whiteBright(`${stepName} is running ...`)
+		const beforeRunHookMessage = chalk.whiteBright(`${label} is running ...`)
+		const afterRunHookMessage = `${chalk.green.bold('✔')} ${chalk.whiteBright(`${label} finished`)}`
 		let message = ''
 		switch (stage) {
 			case TestEvent.BeforeAllStep:
@@ -53,12 +53,12 @@ export class VerboseReporter implements IReporter {
 				console.groupEnd()
 				break
 			case TestEvent.BeforeStep:
-				console.group(chalk.white(beforeRunStepMessage))
+				console.group(beforeRunStepMessage)
 				console.group()
 				break
 			case TestEvent.AfterHookAction:
 			case TestEvent.AfterStepAction:
-				console.log(chalk.grey(`${label}(${args})`))
+				console.log(`${chalk.white(`${label}(${chalk.white.dim(args)})`)}`)
 				break
 			case TestEvent.StepSucceeded:
 				message = `${chalk.green.bold('✔')} ${chalk.green(
@@ -75,7 +75,7 @@ export class VerboseReporter implements IReporter {
 				console.groupEnd()
 				break
 			case TestEvent.StepSkipped:
-				console.group(`${chalk.cyan.bold('\u2296')} ${chalk.cyan(`${stepName} skipped`)}`)
+				console.group(`${chalk.yellow.bold('\u2296')} ${chalk.yellow(`${stepName} skipped`)}`)
 				console.groupEnd()
 				break
 			case TestEvent.StepUnexecuted:

--- a/packages/report/src/reporters/Verbose.ts
+++ b/packages/report/src/reporters/Verbose.ts
@@ -34,7 +34,7 @@ export class VerboseReporter implements IReporter {
 	): void {
 		const stepName = 'Step ' + (subtitle ? `'${label}' (${subtitle})` : `'${label}'`)
 		const beforeRunStepMessage = `${stepName} is running ...`
-		const beforeRunHookMessage = chalk.grey(`${label} is running ...`)
+		const beforeRunHookMessage = chalk.white(`${label} is running ...`)
 		const afterRunHookMessage = `${chalk.green.bold('✔')} ${chalk.grey(`${label} finished`)}`
 		let message = ''
 		switch (stage) {
@@ -53,7 +53,7 @@ export class VerboseReporter implements IReporter {
 				console.groupEnd()
 				break
 			case TestEvent.BeforeStep:
-				console.group(chalk.grey(beforeRunStepMessage))
+				console.group(chalk.white(beforeRunStepMessage))
 				console.group()
 				break
 			case TestEvent.AfterHookAction:
@@ -61,13 +61,13 @@ export class VerboseReporter implements IReporter {
 				console.log(chalk.grey(`${label}(${args})`))
 				break
 			case TestEvent.StepSucceeded:
-				message = `${chalk.green.bold('✔')} ${chalk.grey(
+				message = `${chalk.green.bold('✔')} ${chalk.green(
 					`${stepName} passed (${timing?.toLocaleString()}ms)`,
 				)}`
 				this.updateMessage(beforeRunStepMessage, message)
 				break
 			case TestEvent.StepFailed:
-				message = `${chalk.red.bold('✘')} ${chalk.grey(`${stepName} failed`)}`
+				message = `${chalk.red.bold('✘')} ${chalk.red(`${stepName} failed`)}`
 				console.error(chalk.red(errorMessage?.length ? errorMessage : 'step error -> failed'))
 				this.updateMessage(beforeRunStepMessage, message)
 				break
@@ -75,7 +75,7 @@ export class VerboseReporter implements IReporter {
 				console.groupEnd()
 				break
 			case TestEvent.StepSkipped:
-				console.group(`${chalk.grey.bold('\u2296')} ${chalk.grey(`${stepName} skipped`)}`)
+				console.group(`${chalk.cyan.bold('\u2296')} ${chalk.cyan(`${stepName} skipped`)}`)
 				console.groupEnd()
 				break
 			case TestEvent.StepUnexecuted:


### PR DESCRIPTION
### Base mode (non-verbose)
**Before**
<img width="780" alt="Base-mode-before" src="https://user-images.githubusercontent.com/20455645/100411699-17163300-30a5-11eb-8c5e-8359f0c487ad.png">

**After**
<img width="769" alt="Base-mode-after" src="https://user-images.githubusercontent.com/20455645/100411703-19788d00-30a5-11eb-86d7-6a558a800846.png">
--------------------------------------------------------------------------------------------------------------------
### Verbose mode
**Before**
![Verbose-mode-before](https://user-images.githubusercontent.com/20455645/100412810-395d8000-30a8-11eb-8f0f-db795b7364d8.png)


**After**
![Verbose-mode-after](https://user-images.githubusercontent.com/20455645/100412821-42e6e800-30a8-11eb-8213-e37280f89b79.png)

