### PR TITLE
[Element 2.1] Remove the test path matched message when running single test script

### DIFF
--- a/packages/core/src/Element.ts
+++ b/packages/core/src/Element.ts
@@ -108,7 +108,7 @@ export async function runCommandLine(args: ElementRunArguments): Promise<TestRes
 	}
 
 	if (args.testFiles) {
-		if (!args.runArgs?.file) {
+		if (args.runArgs && !args.runArgs.file) {
 			console.log(
 				chalk.grey(
 					'The following test scripts that matched the testPathMatch pattern are going to be executed:',


### PR DESCRIPTION
Fix the issue that relates to [FLO-2106](https://tricentisflood.atlassian.net/browse/FLO-2106)