### PR TITLE
fix: flood-runner default to run in production env

### DIFF
--- a/packages/flood-runner/src/Environment.ts
+++ b/packages/flood-runner/src/Environment.ts
@@ -42,7 +42,7 @@ export function initFromEnvironment(env: ProcessEnv = process.env): Partial<Grid
 	let root: string
 	let testDataRoot: string
 
-	if (env.NODE_ENV !== 'production') {
+	if (env.NODE_ENV === 'development') {
 		devDefaults(env)
 		const projectRoot = findRoot(__dirname)
 		root = join(projectRoot, 'tmp/data')


### PR DESCRIPTION
This change means `flood-runner` will run in a production environment unless explicitly setting `NODE_ENV` to development. 