### PR TITLE
[Element 2.0] Move spinnies from devDependencies to Dependencies

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,7 +56,8 @@
 		"term-img": "^2.1.0",
 		"typedoc": "^0.15.0",
 		"vm2": "^3.9.1",
-		"winston": "^3.0.0"
+		"winston": "^3.0.0",
+		"spinnies": "^0.5.1"
 	},
 	"devDependencies": {
 		"@types/d3-array": "^1.2.1",
@@ -73,8 +74,7 @@
 		"glob": "^7.1.2",
 		"lodash.upperfirst": "^4.3.1",
 		"morgan": "^1.9.1",
-		"run-script-os": "^1.0.3",
-		"spinnies": "^0.5.1"
+		"run-script-os": "^1.0.3"
 	},
 	"resolutions": {
 		"@types/node": "12.7.4"


### PR DESCRIPTION
Fix this issue 
<img width="1308" alt="Screen Shot 2021-01-22 at 10 07 07" src="https://user-images.githubusercontent.com/20455645/105443377-1ad9c680-5c9e-11eb-8e34-55073df2d891.png">
