### PR TITLE
fix: unknown option --disable-gpu

### DIFF
--- a/packages/core/src/driver/Playwright.ts
+++ b/packages/core/src/driver/Playwright.ts
@@ -116,6 +116,10 @@ export async function launch(
 		...passedOptions,
 	}
 
+	// due to the error "Cannot parse arguments: Unknown option --disable-gpu" when running a test with webkit browser
+	if (options.browser !== 'webkit') {
+		options.args.push('--disable-gpu')
+	}
 	options.args.push('--disable-dev-shm-usage')
 
 	if (!options.sandbox) {

--- a/packages/core/src/driver/Playwright.ts
+++ b/packages/core/src/driver/Playwright.ts
@@ -116,7 +116,6 @@ export async function launch(
 		...passedOptions,
 	}
 
-	options.args.push('--disable-gpu')
 	options.args.push('--disable-dev-shm-usage')
 
 	if (!options.sandbox) {


### PR DESCRIPTION
Fix error: `Cannot parse arguments: Unknown option --disable-gpu` when running a test with `webkit` browser, on a flood-element docker container