### PR TITLE
[Element 2.0] Correct typo of ----show-screenshot

### DIFF
--- a/packages/cli/src/cmd/run.ts
+++ b/packages/cli/src/cmd/run.ts
@@ -274,7 +274,7 @@ const cmd: CommandModule = {
 				describe: 'Export a HTML report after the test finished running',
 				type: 'boolean',
 			})
-			.option('--show-screenshot', {
+			.option('show-screenshot', {
 				describe: 'show screenshot in the terminal (iTerm only)',
 				type: 'boolean',
 			})


### PR DESCRIPTION
Remove redundant `--`.