### PR TITLE
bugfix: cannot create HTML report

### DIFF
--- a/packages/cli/report-tsconfig.json
+++ b/packages/cli/report-tsconfig.json
@@ -1,0 +1,32 @@
+{
+	"compilerOptions": {
+		"module": "CommonJS",
+		"target": "ES5",
+		"moduleResolution": "Node",
+		"lib": ["ESNext", "DOM"],
+		"removeComments": true,
+		"pretty": true,
+		"strictNullChecks": true,
+		"forceConsistentCasingInFileNames": true,
+		"allowUnreachableCode": false,
+		"alwaysStrict": true,
+		"noUnusedLocals": true,
+		"noImplicitAny": false,
+		"allowSyntheticDefaultImports": true,
+		"esModuleInterop": true,
+		"experimentalDecorators": true,
+		"noEmitOnError": true,
+		"emitDecoratorMetadata": true,
+		"composite": true,
+		"outDir": "./dist"
+	},
+	"include": ["**/*.ts"],
+	"exclude": [
+		"**/dist",
+		"*.spec.ts",
+		"*.test.ts",
+		"**/__tests__/**",
+		"**/node_modules",
+		"node_modules"
+	]
+}

--- a/packages/cli/src/cmd/run.ts
+++ b/packages/cli/src/cmd/run.ts
@@ -19,6 +19,7 @@ import sanitize from 'sanitize-filename'
 import { resolve, dirname, basename, extname, join } from 'path'
 import webpack, { Configuration } from 'webpack'
 import CssExtractPlugin from 'mini-css-extract-plugin'
+import findRoot from 'find-root'
 
 interface RunCommonArguments extends Arguments, ElementRunArguments {}
 
@@ -108,7 +109,8 @@ const cmd: CommandModule = {
 				root = join(dirname(configFile), 'reports')
 			}
 
-			const reportRoot = '../../templates/report/'
+			const packageRoot = findRoot(__dirname)
+			const reportRoot = `${packageRoot}/templates/report/`
 			const webpackConfig: Configuration = {
 				entry: resolve(__dirname, reportRoot, 'script.ts'),
 				mode: 'production',
@@ -128,11 +130,8 @@ const cmd: CommandModule = {
 							test: /\.ts$/,
 							loader: require.resolve('ts-loader'),
 							options: {
+								configFile: resolve(__dirname, packageRoot, 'report-tsconfig.json'),
 								onlyCompileBundledFiles: true,
-								compilerOptions: {
-									module: 'commonjs',
-									target: 'es5',
-								},
 							},
 						},
 						{


### PR DESCRIPTION
**Problem:** HTML report cannot be created in production due to:
- Incorrect report template path
- An error when `webpack` processes `tsconfig.json` of the package `@flood/element-cli`

**Solution**:
- Correct the path to report template
- Create a custom `tsconfig.json` for compiling HTML report