### PR TITLE
fix: correct link in test data guide

### DIFF
--- a/packages/docs/versioned_docs/version-1.3/guides/TestData.md
+++ b/packages/docs/versioned_docs/version-1.3/guides/TestData.md
@@ -152,7 +152,7 @@ Its important to understand this when validating data, since for example a value
 
 ## More information
 
-Find more information in the API reference for [TestData], [TestDataFactory] and [TestDataSource], or check out the [Flood challenge with test data](challenge-with-test-data) example script.
+Find more information in the API reference for [TestData], [TestDataFactory] and [TestDataSource], or check out the [Flood challenge with test data] example script.
 
 [TypeScript]: https://www.typescriptlang.org/
 <!-- suffix -->
@@ -161,3 +161,4 @@ Find more information in the API reference for [TestData], [TestDataFactory] and
 [TestData]: ../api/TestData.md#testdata
 [TestDataFactory]: ../api/TestData.md#testdatafactory
 [TestDataSource]: ../api/TestData.md#testdatasource
+[Flood challenge with test data]: https://github.com/flood-io/element/blob/master/examples/flood-challenge.ts

--- a/packages/docs/versioned_docs/version-1.3/guides/TestData.md
+++ b/packages/docs/versioned_docs/version-1.3/guides/TestData.md
@@ -152,7 +152,7 @@ Its important to understand this when validating data, since for example a value
 
 ## More information
 
-Find more information in the API reference for [TestData], [TestDataFactory] and [TestDataSource], or check out the [Flood challenge with test data][challenge-with-test-data] example script.
+Find more information in the API reference for [TestData], [TestDataFactory] and [TestDataSource], or check out the [Flood challenge with test data](challenge-with-test-data) example script.
 
 [TypeScript]: https://www.typescriptlang.org/
 <!-- suffix -->


### PR DESCRIPTION
The "Flood challenge with test data" in the "Using Test Data" guide had the wrong syntax and didn't point anywhere.

This was in the "More information" section at the very bottom.
https://element.flood.io/docs/guides/test-data#more-information

This change point "Flood challenge with test data" to the example script at https://github.com/flood-io/element/blob/master/examples/flood-challenge.ts