### PR TITLE
fix: throw an error if failed to wait for a condition

### DIFF
--- a/packages/core/src/page/Condition.ts
+++ b/packages/core/src/page/Condition.ts
@@ -135,8 +135,8 @@ export abstract class ElementCondition extends LocatorCondition {
 		const args = Array.prototype.concat(this.locator.pageFuncArgs, argSeparator, this.pageFuncArgs)
 		debug('waitFor args', args)
 
-		await frame
-			.waitForFunction(
+		try {
+			await frame.waitForFunction(
 				args => {
 					const [fn, ...rest] = args
 					return eval(fn)(rest)
@@ -144,7 +144,10 @@ export abstract class ElementCondition extends LocatorCondition {
 				[compiledFunc, ...args],
 				options,
 			)
-			.catch(err => console.log(err))
+		} catch (err) {
+			console.log(err)
+			throw err
+		}
 		return true
 	}
 }


### PR DESCRIPTION
A step is still shown as passed even if it failed to wait for a condition (e.g. `Until.elementIsVisible(...)`) => In that case, throw the error out instead of just catch & log it, for the runner to be aware of the error & marks the step as failed.