### PR TITLE
fix: fail to start 2nd iteration when running on Flood

### DIFF
--- a/packages/core/src/Element.ts
+++ b/packages/core/src/Element.ts
@@ -13,7 +13,10 @@ import { ElementResult } from './ElementResult'
 import { join } from 'path'
 import findRoot from 'find-root'
 
-export async function runSingleTestScript(opts: ElementOptions): Promise<IterationResult[]> {
+export async function runSingleTestScript(
+	opts: ElementOptions,
+	spinnies?: any,
+): Promise<IterationResult[]> {
 	const {
 		testScript,
 		clientFactory,
@@ -26,6 +29,12 @@ export async function runSingleTestScript(opts: ElementOptions): Promise<Iterati
 		downloadsPath,
 		showScreenshot,
 	} = opts
+
+	global.console = new CustomConsole(
+		process.stdout,
+		process.stderr,
+		spinnies ? spinnies : new Spinnies(),
+	)
 
 	// TODO proper types for args
 	let runnerClass: { new (...args: any[]): IRunner }
@@ -107,7 +116,7 @@ export async function runCommandLine(args: ElementRunArguments): Promise<TestRes
 		elementResult.addExecutionInfo(opts, isConfig)
 
 		try {
-			const iterationResult = await runSingleTestScript(opts)
+			const iterationResult = await runSingleTestScript(opts, spinnies)
 			elementResult.addTestScript(args.file, iterationResult)
 		} catch (err) {
 			elementResult.addScriptWithError({ name: args.file, error: err.message })

--- a/packages/core/src/Element.ts
+++ b/packages/core/src/Element.ts
@@ -30,11 +30,7 @@ export async function runSingleTestScript(
 		showScreenshot,
 	} = opts
 
-	global.console = new CustomConsole(
-		process.stdout,
-		process.stderr,
-		spinnies ? spinnies : new Spinnies(),
-	)
+	global.console = new CustomConsole(process.stdout, process.stderr, spinnies || new Spinnies())
 
 	// TODO proper types for args
 	let runnerClass: { new (...args: any[]): IRunner }


### PR DESCRIPTION
Apply custom console when running on Flood, which contains the missing method `setGroupDept`