### PR TITLE
[Element Canary] Correct packages's canary version

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
 	"lerna": "2.11.0",
 	"npmClient": "yarn",
-	"version": "2.0.5-canary.0",
+	"version": "2.0.5-canary.1",
 	"useWorkspaces": true,
 	"command": {
 		"init": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "flood-element",
-	"version": "2.0.5-canary.0",
+	"version": "2.0.5-canary.1",
 	"main": "index.js",
 	"repository": "git@github.com:flood-io/element.git",
 	"author": "Ivan Vanderbyl <ivanvanderbyl@gmail.com>",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@flood/element-cli",
-	"version": "2.0.5-canary.0",
+	"version": "2.0.5-canary.1",
 	"license": "Apache-2.0",
 	"description": "The command line interface for Flood Element",
 	"repository": "flood-io/element",
@@ -15,11 +15,11 @@
 		"dev": "ts-node ./bin/element.ts"
 	},
 	"dependencies": {
-		"@flood/element": "2.0.5-canary.0",
-		"@flood/element-api": "2.0.5-canary.0",
-		"@flood/element-core": "2.0.5-canary.0",
-		"@flood/element-flood-runner": "2.0.5-canary.0",
-		"@flood/element-scheduler": "2.0.5-canary.0",
+		"@flood/element": "2.0.5-canary.1",
+		"@flood/element-api": "2.0.5-canary.1",
+		"@flood/element-core": "2.0.5-canary.1",
+		"@flood/element-flood-runner": "2.0.5-canary.1",
+		"@flood/element-scheduler": "2.0.5-canary.1",
 		"@types/find-root": "^1.1.2",
 		"boxen": "^3.0",
 		"chalk": "^2.4.1",

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@flood/element-compiler",
-	"version": "2.0.5-canary.0",
+	"version": "2.0.5-canary.1",
 	"description": "Element internal script compiler",
 	"author": "Ivan Vanderbyl <ivanvanderbyl@gmail.com>",
 	"homepage": "https://github.com/flood-io/element#readme",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@flood/element-core",
-	"version": "2.0.5-canary.0",
+	"version": "2.0.5-canary.1",
 	"description": "Flood Element is a browser based load generation tool for easily testing modern web application performance",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
@@ -30,8 +30,8 @@
 	},
 	"homepage": "https://github.com/flood-io/element#readme",
 	"dependencies": {
-		"@flood/element-compiler": "2.0.5-canary.0",
-		"@flood/element-report": "2.0.5-canary.0",
+		"@flood/element-compiler": "2.0.5-canary.1",
+		"@flood/element-report": "2.0.5-canary.1",
 		"@types/faker": "^4.1.9",
 		"@types/node": "12.7.4",
 		"assert": "^1.4.1",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "element-docs",
-	"version": "2.0.5-canary.0",
+	"version": "2.0.5-canary.1",
 	"private": true,
 	"scripts": {
 		"start": "docusaurus start",

--- a/packages/element-api/package.json
+++ b/packages/element-api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@flood/element-api",
-	"version": "2.0.5-canary.0",
+	"version": "2.0.5-canary.1",
 	"description": "Internal API definitions for Element",
 	"main": "./dist/index.js",
 	"types": "./dist/index.ts.d",
@@ -9,8 +9,8 @@
 		"build": "tsc -b"
 	},
 	"dependencies": {
-		"@flood/element-core": "2.0.5-canary.0",
-		"@flood/element-report": "2.0.5-canary.0"
+		"@flood/element-core": "2.0.5-canary.1",
+		"@flood/element-report": "2.0.5-canary.1"
 	},
 	"devDependencies": {
 		"@types/node": "12.7.4"

--- a/packages/element-cli/package.json
+++ b/packages/element-cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "element-cli",
-	"version": "2.0.5-canary.0",
+	"version": "2.0.5-canary.1",
 	"description": "Element is a real browser load testing tool",
 	"bin": {
 		"element": "./dist/bin/element.js"
@@ -36,7 +36,7 @@
 		"url": "https://github.com/flood-io/element/issues"
 	},
 	"dependencies": {
-		"@flood/element-cli": "2.0.5-canary.0",
+		"@flood/element-cli": "2.0.5-canary.1",
 		"find-root": "^1.1.0",
 		"import-local": "^3.0.2"
 	},

--- a/packages/element-scheduler/package.json
+++ b/packages/element-scheduler/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@flood/element-scheduler",
-	"version": "2.0.5-canary.0",
+	"version": "2.0.5-canary.1",
 	"description": "Handles scheduling ramp and users during a test",
 	"author": "Ivan Vanderbyl <ivanvanderbyl@gmail.com>",
 	"contributors": [
@@ -26,7 +26,7 @@
 		"url": "https://github.com/flood-io/element/issues"
 	},
 	"dependencies": {
-		"@flood/element-core": "2.0.5-canary.0",
+		"@flood/element-core": "2.0.5-canary.1",
 		"cli-table3": "^0.6.0",
 		"logform": "^2.1.2",
 		"merge-stream": "^2.0.0",

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@flood/element",
-	"version": "2.0.5-canary.0",
+	"version": "2.0.5-canary.1",
 	"description": "Element real browser load testing tool",
 	"author": "Ivan Vanderbyl <ivanvanderbyl@gmail.com>",
 	"homepage": "https://element.flood.io",
@@ -22,6 +22,6 @@
 		"url": "https://github.com/flood-io/element/issues"
 	},
 	"dependencies": {
-		"@flood/element-core": "2.0.5-canary.0"
+		"@flood/element-core": "2.0.5-canary.1"
 	}
 }

--- a/packages/flood-runner/package.json
+++ b/packages/flood-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@flood/element-flood-runner",
-	"version": "2.0.5-canary.0",
+	"version": "2.0.5-canary.1",
 	"description": "Flood runner for Element",
 	"author": "Ivan Vanderbyl <ivanvanderbyl@gmail.com>",
 	"homepage": "https://github.com/flood-io/element#readme",
@@ -22,8 +22,8 @@
 		"url": "https://github.com/flood-io/element/issues"
 	},
 	"dependencies": {
-		"@flood/element-core": "2.0.5-canary.0",
-		"@flood/element-report": "2.0.5-canary.0",
+		"@flood/element-core": "2.0.5-canary.1",
+		"@flood/element-report": "2.0.5-canary.1",
 		"@flood/node-influx": "^5.0.9",
 		"find-root": "^1.1.0",
 		"winston": "^3.2.1"


### PR DESCRIPTION
My bad at the **[PR#470](https://github.com/flood-io/element/pull/470)**. Version 2.0.5-canary.1 exists so the Github actions can not publish 2.0.5-canary.1 again. 