### PR TITLE
refactor: rename master to stable

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,10 +7,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master, beta]
+    branches: [stable, beta]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master]
+    branches: [stable]
   schedule:
     - cron: '0 11 * * 0'
 
@@ -47,7 +47,7 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file. 
+        # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 

--- a/.github/workflows/lerna-stable.yml
+++ b/.github/workflows/lerna-stable.yml
@@ -2,7 +2,7 @@ name: Lerna Publish Stable
 
 on:
   pull_request:
-    branches: [master]
+    branches: [stable]
     types: [closed]
 
 jobs:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -40,20 +40,19 @@ Public API for Element testing functionality.
 
 ## Releasing
 
-We ship packages for each release in 3 formats:
+We ship packages for each release in 2 formats:
 
 - NPM (@flood/element)
 - GitHub (tagged archive of source code)
 
 Releases are published automatically and unceremoniously based upon commit history and branch name:
 
-- `feature/*` is the canary release branch.
-- `beta` is the beta release branch.
-- `master` is the stable release branch.
+- `feature/*` is where feature development happens. These branches are not published.
+- `canary` is the canary release branch. You will get the latest features, but expect it to be unstable.
+- `beta` is the beta release branch. Betas are ready for early-adopters to test, but could still contain bugs.
+- `stable` is the stable release branch.
 
-Each time a feature is merged in to `beta`, the commit history is analysed and if it contains changes which require bumping the version, it will be bumped accordingly by `lerna` and `conventional-release` and prereleased with a "beta" tag.
-
-In a similar way, each time `beta` is merged into `master`, the commit history is analysed and the version bumped as needed, this time without a beta tag.
+Each time a feature is merged in to `canary`, the commit history is analysed and if it contains changes which require bumping the version, it will be bumped accordingly by `lerna` and `conventional-release` and pre-released with a "canary" tag. In a similar way, each time `canary` is merged into `beta`, the commit history is analysed and the version bumped as needed, this time with a "beta" tag. Again, each time `beta` is merged into `stable`, the commit history is analysed and the version bumped as needed, this time with no pre-release tags.
 
 NPM releases are handled in CI automatically so that shipping releases isn't a big deal, it should be something we do regularly.
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,18 +1,19 @@
 # Versioning Element
 
-Element uses `lerna publish` to semamtically advance version numbers across all packages. This workflow is automated.
+Element uses `lerna publish` to semantically advance version numbers across all packages. This workflow is automated.
 
 Versions are based on branch:
 
-- `master`: stable releases e.g. `v1.1.0`, and tagged `latest` on NPM.
-- `beta`: next beta release e.g. `v1.1.0-beta.1` and tagged `beta` on NPM.
-- `feature/*`: any feature which will be merged into `beta`. This branch isn't published.
+- `stable`: stable releases e.g. `v1.1.0`, and tagged `latest` on NPM.
+- `beta`: beta releases e.g. `v1.1.0-beta.1` and tagged `beta` on NPM.
+- `canary`: canary releases e.g. `v1.1.0-canary.1` and tagged `canary` on NPM.
+- `feature/*`: any feature which will be merged into `canary`. These branches aren't published.
 
 Versioning pipeline:
 
 ```
            ┌────────────────┐                                         ┌────────────────┐
-master     │     v1.0.0     │─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─│     v1.1.0     │─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─▷
+stable     │     v1.0.0     │─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─│     v1.1.0     │─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─▷
            └────────────────┘                                         └────────────────┘
                     │                                                          ▲
                     │        ┌────────────────┐      ┌────────────────┐        │       ┌────────────────┐

--- a/examples/automation/run-all/flood-runall.sh
+++ b/examples/automation/run-all/flood-runall.sh
@@ -17,7 +17,7 @@ set -e  # exit script if any command returnes a non-zero exit code.
 FLOOD_PROJECT="default"  # "the-internet-dev01"
 GITHUB_REPO_URL="https://github.com/flood-io/element/trunk/examples/sap-fiori"
 
-#TYPESCRIPT_URL="https://raw.githubusercontent.com/flood-io/element/master/examples/internet-herokuapp/14-Dynamic_Loading.ts"
+#TYPESCRIPT_URL="https://raw.githubusercontent.com/flood-io/element/stable/examples/internet-herokuapp/14-Dynamic_Loading.ts"
 FLOOD_REGION="us-west-1"
 FLOOD_INST_TYPE="m5.xlarge"
 FLOOD_SLEEP_SECS="10"

--- a/lerna.json
+++ b/lerna.json
@@ -13,10 +13,9 @@
 		"version": {
 			"message": "chore(release): publish %s\n[skip ci]",
 			"allowBranch": [
-				"master",
+				"stable",
 				"beta",
-				"canary",
-				"feature/*"
+				"canary"
 			]
 		},
 		"bootstrap": {

--- a/packages/core/src/test-data/Loader.ts
+++ b/packages/core/src/test-data/Loader.ts
@@ -215,7 +215,7 @@ export class CSVLoader<T> extends Loader<T> {
 
 		if (this.lines.length === 0) {
 			throw new Error(
-				`CSV file '${this.requestedFilename}' loaded but contains no rows of data.\nNote that the first row of a CSV file is used as the header to name columns.\nFor details see https://github.com/flood-io/element/blob/master/packages/element/docs/examples/examples_test_data.md#csv-column-names`,
+				`CSV file '${this.requestedFilename}' loaded but contains no rows of data.\nNote that the first row of a CSV file is used as the header to name columns.\nFor details see https://github.com/flood-io/element/blob/main/packages/element/docs/examples/examples_test_data.md#csv-column-names`,
 			)
 		}
 

--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -156,7 +156,7 @@ module.exports = {
 			{
 				docs: {
 					sidebarPath: require.resolve('./sidebars.js'),
-					editUrl: 'https://github.com/flood-io/element/edit/master/packages/docs/',
+					editUrl: 'https://github.com/flood-io/element/edit/stable/packages/docs/',
 				},
 				blog: {
 					showReadingTime: true,

--- a/packages/docs/versioned_docs/version-1.0/guides/TestData.md
+++ b/packages/docs/versioned_docs/version-1.0/guides/TestData.md
@@ -161,4 +161,4 @@ Find more information in the API reference for [TestData], [TestDataFactory] and
 [TestData]: ../../api/TestData.md#testdata
 [TestDataFactory]: ../../api/TestData.md#testdatafactory
 [TestDataSource]: ../../api/TestData.md#testdatasource
-[Flood challenge with test data]: https://github.com/flood-io/element/blob/master/examples/flood-challenge.ts
+[Flood challenge with test data]: https://github.com/flood-io/element/blob/main/examples/flood-challenge.ts

--- a/packages/docs/versioned_docs/version-1.3/guides/TestData.md
+++ b/packages/docs/versioned_docs/version-1.3/guides/TestData.md
@@ -161,4 +161,4 @@ Find more information in the API reference for [TestData], [TestDataFactory] and
 [TestData]: ../api/TestData.md#testdata
 [TestDataFactory]: ../api/TestData.md#testdatafactory
 [TestDataSource]: ../api/TestData.md#testdatasource
-[Flood challenge with test data]: https://github.com/flood-io/element/blob/master/examples/flood-challenge.ts
+[Flood challenge with test data]: https://github.com/flood-io/element/blob/stable/examples/flood-challenge.ts

--- a/packages/docs/versioned_docs/version-1.5/guides/TestData.md
+++ b/packages/docs/versioned_docs/version-1.5/guides/TestData.md
@@ -197,4 +197,4 @@ Find more information in the API reference for [TestData], [TestDataFactory] and
 [TestData]: ../api/TestData.md#testdata
 [TestDataFactory]: ../api/TestData.md#testdatafactory
 [TestDataSource]: ../api/TestData.md#testdatasource
-[Flood challenge with test data]: https://github.com/flood-io/element/blob/master/examples/flood-challenge.ts
+[Flood challenge with test data]: https://github.com/flood-io/element/blob/stable/examples/flood-challenge.ts

--- a/packages/docs/versioned_docs/version-2.0/guides/TestData.md
+++ b/packages/docs/versioned_docs/version-2.0/guides/TestData.md
@@ -197,4 +197,4 @@ Find more information in the API reference for [TestData], [TestDataFactory] and
 [TestData]: ../api/TestData.md#testdata
 [TestDataFactory]: ../api/TestData.md#testdatafactory
 [TestDataSource]: ../api/TestData.md#testdatasource
-[Flood challenge with test data]: https://github.com/flood-io/element/blob/master/examples/flood-challenge.ts
+[Flood challenge with test data]: https://github.com/flood-io/element/blob/stable/examples/flood-challenge.ts


### PR DESCRIPTION
The default branch on GH is now `canary`, since this is where PRs should go.

This re-names references to the `master` branch to `stable`, which makes more sense given the other meta version branches are named after their releases (`canary` and `beta`).