### PR TITLE
fix: revert the timing observer to tracing observer change for flood-runner

### DIFF
--- a/packages/core/src/runtime/test-observers/LifecycleObserver.ts
+++ b/packages/core/src/runtime/test-observers/LifecycleObserver.ts
@@ -31,13 +31,10 @@ export default class LifecycleObserver implements TestObserver {
 
 	async onStepPassed(test: Test, step: Step): Promise<void> {
 		const testObserver: TestObserver = this.next
-		let timing = 0
-		if (testObserver instanceof TimingObserver) {
-			timing = await (testObserver as TimingObserver).getMeasurementTime(
-				test.settings.responseTimeMeasurement,
-				true
-			)
-		}
+		const timing = await (testObserver as TimingObserver).getMeasurementTime(
+			test.settings.responseTimeMeasurement,
+			true
+		)
 		step.duration = timing
 		await testObserver.onStepPassed(test, step)
 		test.reporter.testLifecycle(TestEvent.StepSucceeded, step.name, step.subTitle, timing)
@@ -45,13 +42,10 @@ export default class LifecycleObserver implements TestObserver {
 
 	async onStepError(test: Test, step: Step, error: StructuredError<any>): Promise<void> {
 		const testObserver: TestObserver = this.next
-		let timing = 0
-		if (testObserver instanceof TimingObserver) {
-			timing = await (testObserver as TimingObserver).getMeasurementTime(
-				test.settings.responseTimeMeasurement,
-				true
-			)
-		}
+		const timing = await (testObserver as TimingObserver).getMeasurementTime(
+			test.settings.responseTimeMeasurement,
+			true
+		)
 		step.duration = timing
 		await testObserver.onStepError(test, step, error)
 		test.reporter.testLifecycle(
@@ -76,12 +70,9 @@ export default class LifecycleObserver implements TestObserver {
 	async afterStep(test: Test, step: Step): Promise<void> {
 		const testObserver: TestObserver = this.next
 		await testObserver.afterStep(test, step)
-		let timing = 0
-		if (testObserver instanceof TimingObserver) {
-			timing = await (testObserver as TimingObserver).getMeasurementTime(
-				test.settings.responseTimeMeasurement
-			)
-		}
+		const timing = await (testObserver as TimingObserver).getMeasurementTime(
+			test.settings.responseTimeMeasurement
+		)
 		test.reporter.testLifecycle(TestEvent.AfterStep, step.name, step.subTitle, timing)
 	}
 

--- a/packages/flood-runner/src/Grid.ts
+++ b/packages/flood-runner/src/Grid.ts
@@ -1,5 +1,5 @@
 import { runSingleTestScript, ElementOptions, TestObserver } from '@flood/element-api'
-import { Context } from '@flood/element-core'
+import { Context, TimingObserver } from '@flood/element-core'
 import { TracingObserver } from './test-observers/Tracing'
 import { initConfig } from './initConfig'
 import { startConcurrencyTicker } from './tickerInterval'
@@ -11,7 +11,10 @@ export async function run(file: string): Promise<void> {
 
 	const testObserverFactory = (innerObserver: TestObserver) => {
 		const testObserverContext = new Context()
-		return new TracingObserver(testObserverContext, innerObserver)
+		return new TimingObserver(
+			testObserverContext,
+			new TracingObserver(testObserverContext, innerObserver)
+		)
 	}
 
 	const opts: ElementOptions = {


### PR DESCRIPTION
I'm doing this so I can rule in/out these changes for causing the logging problems we're facing with 2.0.