### PR TITLE
Disable printing the update to 2.x message

### DIFF
--- a/packages/cli/src/utils/updateCheck.ts
+++ b/packages/cli/src/utils/updateCheck.ts
@@ -86,9 +86,9 @@ export async function updateCheck(pkg: Package) {
 			distTag,
 		})
 
-		if (update) {
-			printUpdateMessage(pkg.version, distTag, update)
-		}
+		// if (update) {
+		// 	printUpdateMessage(pkg.version, distTag, update)
+		// }
 	} catch (err) {
 		console.error(error(`Checking for updates failed`))
 


### PR DESCRIPTION
Until we resolve some issues in 2.x