### PR TITLE
fix: guard against negative response time measurements

### DIFF
--- a/packages/core/src/runtime/test-observers/TimingObserver.ts
+++ b/packages/core/src/runtime/test-observers/TimingObserver.ts
@@ -126,7 +126,9 @@ export class TimingObserver extends NetworkRecordingTestObserver {
 			test.reporter.responseCode = responseCode
 
 			reporter.addMeasurement('throughput', networkRecorder.networkThroughput(), name)
-			reporter.addMeasurement('response_time', documentResponseTime, name)
+			if (documentResponseTime >= 0) {
+				reporter.addMeasurement('response_time', documentResponseTime, name)
+			}
 			reporter.addMeasurement('latency', documentLatency, name)
 		}
 


### PR DESCRIPTION
Some customers have experienced a handful of large negative response time values being recorded, which sometimes resulted in negative mean response time for a given flood. The root cause is still unknown, but this should prevent those measurements from being recorded.