### PR TITLE
fix: guard against negative response time measurements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
       - run: yarn install
       - run: yarn test
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: 14
       - run: yarn install

--- a/packages/core/src/runtime/test-observers/TimingObserver.ts
+++ b/packages/core/src/runtime/test-observers/TimingObserver.ts
@@ -152,7 +152,9 @@ export class TimingObserver extends NetworkRecordingTestObserver {
 			// reporter.addCompoundMeasurement('browser_performance', browserPerformanceTiming, name)
 
 			reporter.addMeasurement('throughput', networkRecorder.networkThroughput(), name)
-			reporter.addMeasurement('response_time', documentResponseTime, name)
+			if (documentResponseTime >= 0) {
+				reporter.addMeasurement('response_time', documentResponseTime, name)
+			}
 			reporter.addMeasurement('latency', documentLatency, name)
 		}
 


### PR DESCRIPTION
Backporting https://github.com/flood-io/element/pull/552 to element 1.5