### PR TITLE
fix: Fix blocked domains spelling

### DIFF
--- a/packages/cli/templates/element.config.js
+++ b/packages/cli/templates/element.config.js
@@ -26,7 +26,7 @@ module.exports = {
 	},
 	testSettings: {
 		actionDelay: '2s',
-		blockDomains: [],
+		blockedDomains: [],
 		browser: 'chromium',
 		browserLaunchOptions: {},
 		clearCache: false,

--- a/packages/docs/docs/guides/CLI.md
+++ b/packages/docs/docs/guides/CLI.md
@@ -156,7 +156,7 @@ module.exports = {
 	},
 	testSettings: {
 		actionDelay: '2s',
-		blockDomains: [],
+		blockedDomains: [],
 		browser: 'chromium',
 		browserLaunchOptions: {},
 		clearCache: false,

--- a/packages/docs/versioned_docs/version-2.0/guides/CLI.md
+++ b/packages/docs/versioned_docs/version-2.0/guides/CLI.md
@@ -156,7 +156,7 @@ module.exports = {
 	},
 	testSettings: {
 		actionDelay: '2s',
-		blockDomains: [],
+		blockedDomains: [],
 		browser: 'chromium',
 		browserLaunchOptions: {},
 		clearCache: false,


### PR DESCRIPTION
Some of the docs listed the [blockedDomains](https://element.flood.io/docs/guides/test-settings#blockeddomains) test setting as `blockDomains`. 