### PR TITLE
feat: [ISSUE-624] Send worker name as part of step execution.

### DIFF
--- a/packages/core/src/runtime/Test.ts
+++ b/packages/core/src/runtime/Test.ts
@@ -395,7 +395,7 @@ export default class Test implements ITest {
 		try {
 			debug(`Run step: ${step.name}`) // ${step.fn.toString()}`)
 			browser.settings = { ...this.settings, ...step.options }
-			await step.fn.call(null, browser, testDataRecord)
+			await step.fn.call(null, browser, testDataRecord, this.reporter.worker?.name)
 		} catch (err) {
 			error = err
 		} finally {


### PR DESCRIPTION
This helps to have more control over the workers and take better data slicing even with single iteration and parallel running loads.

Consider the following example: 
```
export const settings: TestSettings = {
  loopCount: 1,

  stages: [
    {
      duration: `2m`,
      target: 5,
    },
  ],
};
```

We expect 5 parallel workers being launched, and there is no unique way to identify these workers.
The `TestData` `circular()` or `shuffle` will not help here since they work based on the `loopCount`. `shuffle` to an extent but with duplicates.

With this approach, we will be able to slice the data based on the launched workers and control which to be picked.

More details in #624 

Thank you!